### PR TITLE
dag hooks: onNodeAdded with minor tweaks around dag

### DIFF
--- a/packages/dag/README.md
+++ b/packages/dag/README.md
@@ -46,6 +46,9 @@ export class MyGraph extends React.Component {
 
 ```
 
+Also, take a look to the `dag` stories.
+
+
 ## API
 
 ### editable
@@ -70,12 +73,25 @@ Used to capture edge selection event.
 
 > `function(edge: Object)` | defaults to: `noOp`
 
-Used to create a new edge between node target and source. In order to work the `dag` needs the `editable` prop enabled. `edge` parameter looks like this:
+Used to create a new edge between node target and source. In order to work the `dag` needs the `editable` prop enabled. When the user click on a node, a new "ghost edge" will appear representing the new edge. The function will be called when a different node is clicked. Cancelling the effect otherwise.
+`edge` parameter looks like this:
 
 ```javascript
 // edge parameter description
 { source:String, target: String }
 ```
+
+### onNodeAdded
+
+> `function(node: Object)` | defaults to: `noOp`
+
+Used to create a new node. Only works on `editable` mode. To trigger the new node creation the user will need to doubleClick on the graph component. This shows a new editable node. Cancel with `ESC` key, confirm with `ENTER`. After confirmation, this function will be called with a object like this:
+
+```javascript
+// node parameter description
+{ title: String, x: Number, y: Number}
+```
+Where `x` and `y` are the coords where the user double clicked.
 
 ## FAQs
 

--- a/packages/dag/src/dag.js
+++ b/packages/dag/src/dag.js
@@ -45,7 +45,7 @@ export default class DagCore {
       .append('svg:marker') // This section adds in the arrows
       .attr('id', String)
       .attr('viewBox', '0 -5 10 10')
-      .attr('refX', 72) // refx distanche === node radius
+      .attr('refX', 72) // refx distanche ~= node radius
       .attr('refY', 0)
       .attr('markerWidth', 8) //6
       .attr('markerHeight', 8) //6

--- a/packages/dag/src/edge.js
+++ b/packages/dag/src/edge.js
@@ -1,10 +1,18 @@
 import React, { Component } from 'react';
 import classNames from 'classnames';
-import { select } from 'd3-selection';
+import { select, selectAll } from 'd3-selection';
 import { DEFAULTS } from './dag';
 
-const enterEdge = (selection, theme) => {
+const enterEdge = (selection, ghostEdge) => {
   selection.attr('stroke-width', 1).attr('marker-end', 'url(#end)');
+  if (ghostEdge) {
+    // Note (dk): ghostEdge mode refers to an extra edge which appears
+    // when you try to connect two nodes while in editable mode.
+    selectAll(`.${DEFAULTS.nodeClass}`).each(function() {
+      this.parentNode.appendChild(this);
+    });
+    selection.attr('stroke-width', 1).attr('marker-end', '');
+  }
 };
 
 const updateEdge = selection => {
@@ -22,7 +30,7 @@ export default class Edge extends Component {
   componentDidMount() {
     this.d3Edge = select(this.node)
       .datum(this.props.data)
-      .call(selection => enterEdge(selection));
+      .call(selection => enterEdge(selection, this.props.ghostEdge));
   }
 
   componentDidUpdate() {
@@ -35,10 +43,15 @@ export default class Edge extends Component {
 
   render() {
     // TODO (dk): apply classes.dagEdgeMarker class to marker-end (arrow)
+    const { classes, ghostEdge } = this.props;
+    const edgeClasses = [classes.dagEdge];
+    if (ghostEdge) {
+      edgeClasses.push(classes.dagEdgeGhost);
+    }
     return (
       <line
         ref={node => (this.node = node)}
-        className={classNames(DEFAULTS.linkClass, this.props.classes.dagEdge)}
+        className={classNames(DEFAULTS.linkClass, edgeClasses)}
         onClick={this.handleEdgeClick}
       />
     );

--- a/packages/dag/src/node.js
+++ b/packages/dag/src/node.js
@@ -1,5 +1,4 @@
 import React, { Component } from 'react';
-import { findDOMNode } from 'react-dom';
 import classNames from 'classnames';
 import { select } from 'd3-selection';
 import { DEFAULTS } from './dag';
@@ -57,7 +56,6 @@ export default class Node extends Component {
       .datum(this.props.data)
       .call(selection => enterNode(selection, { ...this.props, onTextChange: this.onTextChange }));
     this.updateLabelBounds();
-    this.domNode = findDOMNode(this);
   }
 
   componentDidUpdate() {
@@ -67,19 +65,25 @@ export default class Node extends Component {
   updateLabelBounds = () => {
     var rect = this.label.getBoundingClientRect();
     this.setState({
-      labelX: this.props.data.x,
-      labelY: this.props.data.y + Math.max(16, rect.height),
+      labelX: this.props.data.x - 20,
+      labelY: this.props.data.y - 8,
       labelWidth: Math.max(50, rect.width),
-      labelHeight: Math.max(16, rect.height)
+      labelHeight: Math.max(20, rect.height)
     });
   };
 
   handleNodeClick = e => {
+    const node = {
+      title: this.props.name,
+      x: this.props.data.x,
+      y: this.props.data.y
+    };
+
     if (this.props.editable) {
-      this.props.editSelectedNode(this.props.name);
+      this.props.editSelectedNode(node);
     }
 
-    this.props.onNodeClick.call(this, e);
+    this.props.onNodeClick(node);
   };
 
   onTextChange = e => {
@@ -98,6 +102,7 @@ export default class Node extends Component {
           ...this.props.data,
           name: this.state.text
         });
+        this.props.closeNode();
         break;
       case 27:
         // esc key
@@ -109,7 +114,7 @@ export default class Node extends Component {
   };
 
   render() {
-    const { newNode } = this.props;
+    const { newNode, outerEl } = this.props;
 
     return (
       <g
@@ -121,7 +126,7 @@ export default class Node extends Component {
         <text ref={node => (this.label = node)} className={this.props.classes.dagNodeText} />
         {newNode &&
           this.props.children({
-            domNode: this.domNode,
+            outerEl,
             onTextChange: this.onTextChange,
             onKeyDown: this.onKeyDown,
             value: this.state.text,

--- a/packages/dag/stories/index.js
+++ b/packages/dag/stories/index.js
@@ -56,14 +56,16 @@ const PaperWrap = ({ children }) => (
   </Paper>
 );
 
-export default ({ storiesOf, action }) => {
+export default ({ storiesOf, action, forceReRender }) => {
   storiesOf('dag/basic', module)
     .add('no wrapper', () => {
       // TODO(dk): parse real pkg json deps.
       return <Dag onClick={action('clicked')} {...getProps()} />;
     })
     .add('editable mode', () => {
-      return <Dag editable={true} onEdgeAdded={action('onEdgeAdded')} {...getProps()} />;
+      return (
+        <Dag editable={true} onEdgeAdded={action('onEdgeAdded')} onNodeAdded={action('onNodeAdded')} {...getProps()} />
+      );
     });
 
   storiesOf('dag/themed', module)

--- a/packages/dag/test/__snapshots__/storyshot.test.js.snap
+++ b/packages/dag/test/__snapshots__/storyshot.test.js.snap
@@ -13,6 +13,7 @@ exports[`Storyshots dag/basic editable mode 1`] = `
     height={500}
     onDoubleClick={[Function]}
     onMouseMove={[Function]}
+    onMouseUp={[Function]}
     width={500}
   >
     <g
@@ -114,6 +115,7 @@ exports[`Storyshots dag/basic no wrapper 1`] = `
     height={500}
     onDoubleClick={[Function]}
     onMouseMove={[Function]}
+    onMouseUp={[Function]}
     width={500}
   >
     <g
@@ -232,6 +234,7 @@ exports[`Storyshots dag/themed paper wrapper (dark) 1`] = `
         height={500}
         onDoubleClick={[Function]}
         onMouseMove={[Function]}
+        onMouseUp={[Function]}
         width={500}
       >
         <g
@@ -352,6 +355,7 @@ exports[`Storyshots dag/themed paper wrapper (light) 1`] = `
         height={500}
         onDoubleClick={[Function]}
         onMouseMove={[Function]}
+        onMouseUp={[Function]}
         width={500}
       >
         <g

--- a/packages/dag/test/__snapshots__/storyshot.test.js.snap
+++ b/packages/dag/test/__snapshots__/storyshot.test.js.snap
@@ -9,90 +9,91 @@ exports[`Storyshots dag/basic editable mode 1`] = `
   }
 >
   <svg
-    className="dag-wrapper Dag-root-6"
+    className="dag-wrapper Dag-root-7"
     height={500}
     onDoubleClick={[Function]}
+    onMouseMove={[Function]}
     width={500}
   >
     <g
       className="graph"
     >
       <line
-        className="connect-node Dag-dagEdge-9"
+        className="connect-node Dag-dagEdge-10"
         onClick={[Function]}
       />
       <line
-        className="connect-node Dag-dagEdge-9"
+        className="connect-node Dag-dagEdge-10"
         onClick={[Function]}
       />
       <line
-        className="connect-node Dag-dagEdge-9"
+        className="connect-node Dag-dagEdge-10"
         onClick={[Function]}
       />
       <line
-        className="connect-node Dag-dagEdge-9"
+        className="connect-node Dag-dagEdge-10"
         onClick={[Function]}
       />
       <line
-        className="connect-node Dag-dagEdge-9"
+        className="connect-node Dag-dagEdge-10"
         onClick={[Function]}
       />
       <line
-        className="connect-node Dag-dagEdge-9"
+        className="connect-node Dag-dagEdge-10"
         onClick={[Function]}
       />
       <g
-        className="node Dag-dagNode-7"
+        className="node Dag-dagNode-8"
         onClick={[Function]}
       >
         <circle />
         <text
-          className="Dag-dagNodeText-8"
+          className="Dag-dagNodeText-9"
         />
       </g>
       <g
-        className="node Dag-dagNode-7"
+        className="node Dag-dagNode-8"
         onClick={[Function]}
       >
         <circle />
         <text
-          className="Dag-dagNodeText-8"
+          className="Dag-dagNodeText-9"
         />
       </g>
       <g
-        className="node Dag-dagNode-7"
+        className="node Dag-dagNode-8"
         onClick={[Function]}
       >
         <circle />
         <text
-          className="Dag-dagNodeText-8"
+          className="Dag-dagNodeText-9"
         />
       </g>
       <g
-        className="node Dag-dagNode-7"
+        className="node Dag-dagNode-8"
         onClick={[Function]}
       >
         <circle />
         <text
-          className="Dag-dagNodeText-8"
+          className="Dag-dagNodeText-9"
         />
       </g>
       <g
-        className="node Dag-dagNode-7"
+        className="node Dag-dagNode-8"
         onClick={[Function]}
       >
         <circle />
         <text
-          className="Dag-dagNodeText-8"
+          className="Dag-dagNodeText-9"
         />
       </g>
       <g
-        className="node Dag-dagNode-7"
+        className="node Dag-dagNode-8"
         onClick={[Function]}
       >
         <circle />
         <text
-          className="Dag-dagNodeText-8"
+          className="Dag-dagNodeText-9"
         />
       </g>
     </g>
@@ -112,6 +113,7 @@ exports[`Storyshots dag/basic no wrapper 1`] = `
     className="dag-wrapper Dag-root-1"
     height={500}
     onDoubleClick={[Function]}
+    onMouseMove={[Function]}
     width={500}
   >
     <g
@@ -210,7 +212,7 @@ exports[`Storyshots dag/themed paper wrapper (dark) 1`] = `
   }
 >
   <div
-    className="MuiPaper-root-43 MuiPaper-elevation2-47 MuiPaper-rounded-44"
+    className="MuiPaper-root-46 MuiPaper-elevation2-50 MuiPaper-rounded-47"
     style={
       Object {
         "height": "500px",
@@ -226,90 +228,91 @@ exports[`Storyshots dag/themed paper wrapper (dark) 1`] = `
       }
     >
       <svg
-        className="dag-wrapper Dag-root-70"
+        className="dag-wrapper Dag-root-73"
         height={500}
         onDoubleClick={[Function]}
+        onMouseMove={[Function]}
         width={500}
       >
         <g
           className="graph"
         >
           <line
-            className="connect-node Dag-dagEdge-73"
+            className="connect-node Dag-dagEdge-76"
             onClick={[Function]}
           />
           <line
-            className="connect-node Dag-dagEdge-73"
+            className="connect-node Dag-dagEdge-76"
             onClick={[Function]}
           />
           <line
-            className="connect-node Dag-dagEdge-73"
+            className="connect-node Dag-dagEdge-76"
             onClick={[Function]}
           />
           <line
-            className="connect-node Dag-dagEdge-73"
+            className="connect-node Dag-dagEdge-76"
             onClick={[Function]}
           />
           <line
-            className="connect-node Dag-dagEdge-73"
+            className="connect-node Dag-dagEdge-76"
             onClick={[Function]}
           />
           <line
-            className="connect-node Dag-dagEdge-73"
+            className="connect-node Dag-dagEdge-76"
             onClick={[Function]}
           />
           <g
-            className="node Dag-dagNode-71"
+            className="node Dag-dagNode-74"
             onClick={[Function]}
           >
             <circle />
             <text
-              className="Dag-dagNodeText-72"
+              className="Dag-dagNodeText-75"
             />
           </g>
           <g
-            className="node Dag-dagNode-71"
+            className="node Dag-dagNode-74"
             onClick={[Function]}
           >
             <circle />
             <text
-              className="Dag-dagNodeText-72"
+              className="Dag-dagNodeText-75"
             />
           </g>
           <g
-            className="node Dag-dagNode-71"
+            className="node Dag-dagNode-74"
             onClick={[Function]}
           >
             <circle />
             <text
-              className="Dag-dagNodeText-72"
+              className="Dag-dagNodeText-75"
             />
           </g>
           <g
-            className="node Dag-dagNode-71"
+            className="node Dag-dagNode-74"
             onClick={[Function]}
           >
             <circle />
             <text
-              className="Dag-dagNodeText-72"
+              className="Dag-dagNodeText-75"
             />
           </g>
           <g
-            className="node Dag-dagNode-71"
+            className="node Dag-dagNode-74"
             onClick={[Function]}
           >
             <circle />
             <text
-              className="Dag-dagNodeText-72"
+              className="Dag-dagNodeText-75"
             />
           </g>
           <g
-            className="node Dag-dagNode-71"
+            className="node Dag-dagNode-74"
             onClick={[Function]}
           >
             <circle />
             <text
-              className="Dag-dagNodeText-72"
+              className="Dag-dagNodeText-75"
             />
           </g>
         </g>
@@ -329,7 +332,7 @@ exports[`Storyshots dag/themed paper wrapper (light) 1`] = `
   }
 >
   <div
-    className="MuiPaper-root-11 MuiPaper-elevation2-15 MuiPaper-rounded-12"
+    className="MuiPaper-root-13 MuiPaper-elevation2-17 MuiPaper-rounded-14"
     style={
       Object {
         "height": "500px",
@@ -345,90 +348,91 @@ exports[`Storyshots dag/themed paper wrapper (light) 1`] = `
       }
     >
       <svg
-        className="dag-wrapper Dag-root-38"
+        className="dag-wrapper Dag-root-40"
         height={500}
         onDoubleClick={[Function]}
+        onMouseMove={[Function]}
         width={500}
       >
         <g
           className="graph"
         >
           <line
-            className="connect-node Dag-dagEdge-41"
+            className="connect-node Dag-dagEdge-43"
             onClick={[Function]}
           />
           <line
-            className="connect-node Dag-dagEdge-41"
+            className="connect-node Dag-dagEdge-43"
             onClick={[Function]}
           />
           <line
-            className="connect-node Dag-dagEdge-41"
+            className="connect-node Dag-dagEdge-43"
             onClick={[Function]}
           />
           <line
-            className="connect-node Dag-dagEdge-41"
+            className="connect-node Dag-dagEdge-43"
             onClick={[Function]}
           />
           <line
-            className="connect-node Dag-dagEdge-41"
+            className="connect-node Dag-dagEdge-43"
             onClick={[Function]}
           />
           <line
-            className="connect-node Dag-dagEdge-41"
+            className="connect-node Dag-dagEdge-43"
             onClick={[Function]}
           />
           <g
-            className="node Dag-dagNode-39"
+            className="node Dag-dagNode-41"
             onClick={[Function]}
           >
             <circle />
             <text
-              className="Dag-dagNodeText-40"
+              className="Dag-dagNodeText-42"
             />
           </g>
           <g
-            className="node Dag-dagNode-39"
+            className="node Dag-dagNode-41"
             onClick={[Function]}
           >
             <circle />
             <text
-              className="Dag-dagNodeText-40"
+              className="Dag-dagNodeText-42"
             />
           </g>
           <g
-            className="node Dag-dagNode-39"
+            className="node Dag-dagNode-41"
             onClick={[Function]}
           >
             <circle />
             <text
-              className="Dag-dagNodeText-40"
+              className="Dag-dagNodeText-42"
             />
           </g>
           <g
-            className="node Dag-dagNode-39"
+            className="node Dag-dagNode-41"
             onClick={[Function]}
           >
             <circle />
             <text
-              className="Dag-dagNodeText-40"
+              className="Dag-dagNodeText-42"
             />
           </g>
           <g
-            className="node Dag-dagNode-39"
+            className="node Dag-dagNode-41"
             onClick={[Function]}
           >
             <circle />
             <text
-              className="Dag-dagNodeText-40"
+              className="Dag-dagNodeText-42"
             />
           </g>
           <g
-            className="node Dag-dagNode-39"
+            className="node Dag-dagNode-41"
             onClick={[Function]}
           >
             <circle />
             <text
-              className="Dag-dagNodeText-40"
+              className="Dag-dagNodeText-42"
             />
           </g>
         </g>

--- a/packages/dag/test/__snapshots__/storyshot.test.js.snap
+++ b/packages/dag/test/__snapshots__/storyshot.test.js.snap
@@ -1,185 +1,203 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Storyshots dag/basic editable mode 1`] = `
-<svg
-  className="dag-wrapper Dag-root-6"
-  height={500}
-  width={500}
+<div
+  style={
+    Object {
+      "position": "relative",
+    }
+  }
 >
-  <g
-    className="graph"
+  <svg
+    className="dag-wrapper Dag-root-6"
+    height={500}
+    onDoubleClick={[Function]}
+    width={500}
   >
-    <line
-      className="connect-node Dag-dagEdge-9"
-      onClick={[Function]}
-    />
-    <line
-      className="connect-node Dag-dagEdge-9"
-      onClick={[Function]}
-    />
-    <line
-      className="connect-node Dag-dagEdge-9"
-      onClick={[Function]}
-    />
-    <line
-      className="connect-node Dag-dagEdge-9"
-      onClick={[Function]}
-    />
-    <line
-      className="connect-node Dag-dagEdge-9"
-      onClick={[Function]}
-    />
-    <line
-      className="connect-node Dag-dagEdge-9"
-      onClick={[Function]}
-    />
     <g
-      className="node Dag-dagNode-7"
-      onClick={[Function]}
+      className="graph"
     >
-      <circle />
-      <text
-        className="Dag-dagNodeText-8"
+      <line
+        className="connect-node Dag-dagEdge-9"
+        onClick={[Function]}
       />
-    </g>
-    <g
-      className="node Dag-dagNode-7"
-      onClick={[Function]}
-    >
-      <circle />
-      <text
-        className="Dag-dagNodeText-8"
+      <line
+        className="connect-node Dag-dagEdge-9"
+        onClick={[Function]}
       />
-    </g>
-    <g
-      className="node Dag-dagNode-7"
-      onClick={[Function]}
-    >
-      <circle />
-      <text
-        className="Dag-dagNodeText-8"
+      <line
+        className="connect-node Dag-dagEdge-9"
+        onClick={[Function]}
       />
-    </g>
-    <g
-      className="node Dag-dagNode-7"
-      onClick={[Function]}
-    >
-      <circle />
-      <text
-        className="Dag-dagNodeText-8"
+      <line
+        className="connect-node Dag-dagEdge-9"
+        onClick={[Function]}
       />
-    </g>
-    <g
-      className="node Dag-dagNode-7"
-      onClick={[Function]}
-    >
-      <circle />
-      <text
-        className="Dag-dagNodeText-8"
+      <line
+        className="connect-node Dag-dagEdge-9"
+        onClick={[Function]}
       />
-    </g>
-    <g
-      className="node Dag-dagNode-7"
-      onClick={[Function]}
-    >
-      <circle />
-      <text
-        className="Dag-dagNodeText-8"
+      <line
+        className="connect-node Dag-dagEdge-9"
+        onClick={[Function]}
       />
+      <g
+        className="node Dag-dagNode-7"
+        onClick={[Function]}
+      >
+        <circle />
+        <text
+          className="Dag-dagNodeText-8"
+        />
+      </g>
+      <g
+        className="node Dag-dagNode-7"
+        onClick={[Function]}
+      >
+        <circle />
+        <text
+          className="Dag-dagNodeText-8"
+        />
+      </g>
+      <g
+        className="node Dag-dagNode-7"
+        onClick={[Function]}
+      >
+        <circle />
+        <text
+          className="Dag-dagNodeText-8"
+        />
+      </g>
+      <g
+        className="node Dag-dagNode-7"
+        onClick={[Function]}
+      >
+        <circle />
+        <text
+          className="Dag-dagNodeText-8"
+        />
+      </g>
+      <g
+        className="node Dag-dagNode-7"
+        onClick={[Function]}
+      >
+        <circle />
+        <text
+          className="Dag-dagNodeText-8"
+        />
+      </g>
+      <g
+        className="node Dag-dagNode-7"
+        onClick={[Function]}
+      >
+        <circle />
+        <text
+          className="Dag-dagNodeText-8"
+        />
+      </g>
     </g>
-  </g>
-</svg>
+  </svg>
+</div>
 `;
 
 exports[`Storyshots dag/basic no wrapper 1`] = `
-<svg
-  className="dag-wrapper Dag-root-1"
-  height={500}
-  width={500}
+<div
+  style={
+    Object {
+      "position": "relative",
+    }
+  }
 >
-  <g
-    className="graph"
+  <svg
+    className="dag-wrapper Dag-root-1"
+    height={500}
+    onDoubleClick={[Function]}
+    width={500}
   >
-    <line
-      className="connect-node Dag-dagEdge-4"
-      onClick={[Function]}
-    />
-    <line
-      className="connect-node Dag-dagEdge-4"
-      onClick={[Function]}
-    />
-    <line
-      className="connect-node Dag-dagEdge-4"
-      onClick={[Function]}
-    />
-    <line
-      className="connect-node Dag-dagEdge-4"
-      onClick={[Function]}
-    />
-    <line
-      className="connect-node Dag-dagEdge-4"
-      onClick={[Function]}
-    />
-    <line
-      className="connect-node Dag-dagEdge-4"
-      onClick={[Function]}
-    />
     <g
-      className="node Dag-dagNode-2"
-      onClick={[Function]}
+      className="graph"
     >
-      <circle />
-      <text
-        className="Dag-dagNodeText-3"
+      <line
+        className="connect-node Dag-dagEdge-4"
+        onClick={[Function]}
       />
-    </g>
-    <g
-      className="node Dag-dagNode-2"
-      onClick={[Function]}
-    >
-      <circle />
-      <text
-        className="Dag-dagNodeText-3"
+      <line
+        className="connect-node Dag-dagEdge-4"
+        onClick={[Function]}
       />
-    </g>
-    <g
-      className="node Dag-dagNode-2"
-      onClick={[Function]}
-    >
-      <circle />
-      <text
-        className="Dag-dagNodeText-3"
+      <line
+        className="connect-node Dag-dagEdge-4"
+        onClick={[Function]}
       />
-    </g>
-    <g
-      className="node Dag-dagNode-2"
-      onClick={[Function]}
-    >
-      <circle />
-      <text
-        className="Dag-dagNodeText-3"
+      <line
+        className="connect-node Dag-dagEdge-4"
+        onClick={[Function]}
       />
-    </g>
-    <g
-      className="node Dag-dagNode-2"
-      onClick={[Function]}
-    >
-      <circle />
-      <text
-        className="Dag-dagNodeText-3"
+      <line
+        className="connect-node Dag-dagEdge-4"
+        onClick={[Function]}
       />
-    </g>
-    <g
-      className="node Dag-dagNode-2"
-      onClick={[Function]}
-    >
-      <circle />
-      <text
-        className="Dag-dagNodeText-3"
+      <line
+        className="connect-node Dag-dagEdge-4"
+        onClick={[Function]}
       />
+      <g
+        className="node Dag-dagNode-2"
+        onClick={[Function]}
+      >
+        <circle />
+        <text
+          className="Dag-dagNodeText-3"
+        />
+      </g>
+      <g
+        className="node Dag-dagNode-2"
+        onClick={[Function]}
+      >
+        <circle />
+        <text
+          className="Dag-dagNodeText-3"
+        />
+      </g>
+      <g
+        className="node Dag-dagNode-2"
+        onClick={[Function]}
+      >
+        <circle />
+        <text
+          className="Dag-dagNodeText-3"
+        />
+      </g>
+      <g
+        className="node Dag-dagNode-2"
+        onClick={[Function]}
+      >
+        <circle />
+        <text
+          className="Dag-dagNodeText-3"
+        />
+      </g>
+      <g
+        className="node Dag-dagNode-2"
+        onClick={[Function]}
+      >
+        <circle />
+        <text
+          className="Dag-dagNodeText-3"
+        />
+      </g>
+      <g
+        className="node Dag-dagNode-2"
+        onClick={[Function]}
+      >
+        <circle />
+        <text
+          className="Dag-dagNodeText-3"
+        />
+      </g>
     </g>
-  </g>
-</svg>
+  </svg>
+</div>
 `;
 
 exports[`Storyshots dag/themed paper wrapper (dark) 1`] = `
@@ -200,94 +218,103 @@ exports[`Storyshots dag/themed paper wrapper (dark) 1`] = `
       }
     }
   >
-    <svg
-      className="dag-wrapper Dag-root-70"
-      height={500}
-      width={500}
+    <div
+      style={
+        Object {
+          "position": "relative",
+        }
+      }
     >
-      <g
-        className="graph"
+      <svg
+        className="dag-wrapper Dag-root-70"
+        height={500}
+        onDoubleClick={[Function]}
+        width={500}
       >
-        <line
-          className="connect-node Dag-dagEdge-73"
-          onClick={[Function]}
-        />
-        <line
-          className="connect-node Dag-dagEdge-73"
-          onClick={[Function]}
-        />
-        <line
-          className="connect-node Dag-dagEdge-73"
-          onClick={[Function]}
-        />
-        <line
-          className="connect-node Dag-dagEdge-73"
-          onClick={[Function]}
-        />
-        <line
-          className="connect-node Dag-dagEdge-73"
-          onClick={[Function]}
-        />
-        <line
-          className="connect-node Dag-dagEdge-73"
-          onClick={[Function]}
-        />
         <g
-          className="node Dag-dagNode-71"
-          onClick={[Function]}
+          className="graph"
         >
-          <circle />
-          <text
-            className="Dag-dagNodeText-72"
+          <line
+            className="connect-node Dag-dagEdge-73"
+            onClick={[Function]}
           />
-        </g>
-        <g
-          className="node Dag-dagNode-71"
-          onClick={[Function]}
-        >
-          <circle />
-          <text
-            className="Dag-dagNodeText-72"
+          <line
+            className="connect-node Dag-dagEdge-73"
+            onClick={[Function]}
           />
-        </g>
-        <g
-          className="node Dag-dagNode-71"
-          onClick={[Function]}
-        >
-          <circle />
-          <text
-            className="Dag-dagNodeText-72"
+          <line
+            className="connect-node Dag-dagEdge-73"
+            onClick={[Function]}
           />
-        </g>
-        <g
-          className="node Dag-dagNode-71"
-          onClick={[Function]}
-        >
-          <circle />
-          <text
-            className="Dag-dagNodeText-72"
+          <line
+            className="connect-node Dag-dagEdge-73"
+            onClick={[Function]}
           />
-        </g>
-        <g
-          className="node Dag-dagNode-71"
-          onClick={[Function]}
-        >
-          <circle />
-          <text
-            className="Dag-dagNodeText-72"
+          <line
+            className="connect-node Dag-dagEdge-73"
+            onClick={[Function]}
           />
-        </g>
-        <g
-          className="node Dag-dagNode-71"
-          onClick={[Function]}
-        >
-          <circle />
-          <text
-            className="Dag-dagNodeText-72"
+          <line
+            className="connect-node Dag-dagEdge-73"
+            onClick={[Function]}
           />
+          <g
+            className="node Dag-dagNode-71"
+            onClick={[Function]}
+          >
+            <circle />
+            <text
+              className="Dag-dagNodeText-72"
+            />
+          </g>
+          <g
+            className="node Dag-dagNode-71"
+            onClick={[Function]}
+          >
+            <circle />
+            <text
+              className="Dag-dagNodeText-72"
+            />
+          </g>
+          <g
+            className="node Dag-dagNode-71"
+            onClick={[Function]}
+          >
+            <circle />
+            <text
+              className="Dag-dagNodeText-72"
+            />
+          </g>
+          <g
+            className="node Dag-dagNode-71"
+            onClick={[Function]}
+          >
+            <circle />
+            <text
+              className="Dag-dagNodeText-72"
+            />
+          </g>
+          <g
+            className="node Dag-dagNode-71"
+            onClick={[Function]}
+          >
+            <circle />
+            <text
+              className="Dag-dagNodeText-72"
+            />
+          </g>
+          <g
+            className="node Dag-dagNode-71"
+            onClick={[Function]}
+          >
+            <circle />
+            <text
+              className="Dag-dagNodeText-72"
+            />
+          </g>
         </g>
-      </g>
-    </svg>
+      </svg>
+    </div>
   </div>
 </div>
 `;
@@ -310,94 +337,103 @@ exports[`Storyshots dag/themed paper wrapper (light) 1`] = `
       }
     }
   >
-    <svg
-      className="dag-wrapper Dag-root-38"
-      height={500}
-      width={500}
+    <div
+      style={
+        Object {
+          "position": "relative",
+        }
+      }
     >
-      <g
-        className="graph"
+      <svg
+        className="dag-wrapper Dag-root-38"
+        height={500}
+        onDoubleClick={[Function]}
+        width={500}
       >
-        <line
-          className="connect-node Dag-dagEdge-41"
-          onClick={[Function]}
-        />
-        <line
-          className="connect-node Dag-dagEdge-41"
-          onClick={[Function]}
-        />
-        <line
-          className="connect-node Dag-dagEdge-41"
-          onClick={[Function]}
-        />
-        <line
-          className="connect-node Dag-dagEdge-41"
-          onClick={[Function]}
-        />
-        <line
-          className="connect-node Dag-dagEdge-41"
-          onClick={[Function]}
-        />
-        <line
-          className="connect-node Dag-dagEdge-41"
-          onClick={[Function]}
-        />
         <g
-          className="node Dag-dagNode-39"
-          onClick={[Function]}
+          className="graph"
         >
-          <circle />
-          <text
-            className="Dag-dagNodeText-40"
+          <line
+            className="connect-node Dag-dagEdge-41"
+            onClick={[Function]}
           />
-        </g>
-        <g
-          className="node Dag-dagNode-39"
-          onClick={[Function]}
-        >
-          <circle />
-          <text
-            className="Dag-dagNodeText-40"
+          <line
+            className="connect-node Dag-dagEdge-41"
+            onClick={[Function]}
           />
-        </g>
-        <g
-          className="node Dag-dagNode-39"
-          onClick={[Function]}
-        >
-          <circle />
-          <text
-            className="Dag-dagNodeText-40"
+          <line
+            className="connect-node Dag-dagEdge-41"
+            onClick={[Function]}
           />
-        </g>
-        <g
-          className="node Dag-dagNode-39"
-          onClick={[Function]}
-        >
-          <circle />
-          <text
-            className="Dag-dagNodeText-40"
+          <line
+            className="connect-node Dag-dagEdge-41"
+            onClick={[Function]}
           />
-        </g>
-        <g
-          className="node Dag-dagNode-39"
-          onClick={[Function]}
-        >
-          <circle />
-          <text
-            className="Dag-dagNodeText-40"
+          <line
+            className="connect-node Dag-dagEdge-41"
+            onClick={[Function]}
           />
-        </g>
-        <g
-          className="node Dag-dagNode-39"
-          onClick={[Function]}
-        >
-          <circle />
-          <text
-            className="Dag-dagNodeText-40"
+          <line
+            className="connect-node Dag-dagEdge-41"
+            onClick={[Function]}
           />
+          <g
+            className="node Dag-dagNode-39"
+            onClick={[Function]}
+          >
+            <circle />
+            <text
+              className="Dag-dagNodeText-40"
+            />
+          </g>
+          <g
+            className="node Dag-dagNode-39"
+            onClick={[Function]}
+          >
+            <circle />
+            <text
+              className="Dag-dagNodeText-40"
+            />
+          </g>
+          <g
+            className="node Dag-dagNode-39"
+            onClick={[Function]}
+          >
+            <circle />
+            <text
+              className="Dag-dagNodeText-40"
+            />
+          </g>
+          <g
+            className="node Dag-dagNode-39"
+            onClick={[Function]}
+          >
+            <circle />
+            <text
+              className="Dag-dagNodeText-40"
+            />
+          </g>
+          <g
+            className="node Dag-dagNode-39"
+            onClick={[Function]}
+          >
+            <circle />
+            <text
+              className="Dag-dagNodeText-40"
+            />
+          </g>
+          <g
+            className="node Dag-dagNode-39"
+            onClick={[Function]}
+          >
+            <circle />
+            <text
+              className="Dag-dagNodeText-40"
+            />
+          </g>
         </g>
-      </g>
-    </svg>
+      </svg>
+    </div>
   </div>
 </div>
 `;

--- a/packages/dag/test/storyshot.test.js
+++ b/packages/dag/test/storyshot.test.js
@@ -1,3 +1,18 @@
-import initStoryshots from '@storybook/addon-storyshots';
+import initStoryshots, { snapshotWithOptions } from '@storybook/addon-storyshots';
 
-initStoryshots();
+function createNodeMock(element) {
+  if (element.type === 'text') {
+    return {
+      getBoundingClientRect() {
+        return {};
+      }
+    };
+  }
+  return null;
+}
+
+initStoryshots({
+  test: snapshotWithOptions({
+    createNodeMock
+  })
+});


### PR DESCRIPTION
related to #86 

This PR adds initial support for onNodeAdded cb. The code update includes the possibility to render child props inside nodes, in particular, uses this feature along with react portals for rendering an (dom detached) input component for editing the new node. 

