### PR TITLE
dag:  add remove hooks with custom UI (panels)

### DIFF
--- a/packages/dag/README.md
+++ b/packages/dag/README.md
@@ -46,7 +46,7 @@ export class MyGraph extends React.Component {
 
 ```
 
-Also, take a look to the `dag` stories.
+:arrow_right: Also, take a look to the `dag` stories.
 
 
 ## API
@@ -59,26 +59,26 @@ Indicates if the `dag` can be edited, eg: new edges can be added. This mode enda
 
 ### onNodeClick
 
-> `function(event: Object)` | defaults to: `noOp`
+> `function(node: Object)` | defaults to: `noOp`
 
-Used to capture node selection event.
+Used to get the selected node. Click on a node also adds the `selectedNodeClass` to target node. See exported `DAG_DEFAULTS` object.
 
 ### onEdgeClick
 
-> `function(event: Object)` | defaults to: `noOp`
+> `function(edge: Object)` | defaults to: `noOp`
 
-Used to capture edge selection event.
+Used to get the selected edge. Click on an edge also adds the `selectedEdgeClass` to target edge. See exported `DAG_DEFAULTS` object.
 
 ### onEdgeAdded
 
 > `function(edge: Object)` | defaults to: `noOp`
 
-Used to create a new edge between node target and source. In order to work the `dag` needs the `editable` prop enabled. When the user click on a node, a new "ghost edge" will appear representing the new edge. The function will be called when a different node is clicked. Cancelling the effect otherwise.
+Used to create a new edge between node target and source. In order to work the `dag` needs the `editable` prop enabled. When the user clicks on a node, a new _panel_ will appear where they can select actions to trigger. If they select to create a new edge, then a new "ghost edge" will show representing a new connection between nodes. Initial node will be the **source**. The cb function will be called when a different node (**target**) is clicked.
 `edge` parameter looks like this:
 
 ```javascript
 // edge parameter description
-{ source:String, target: String }
+{ source: String, target: String }
 ```
 
 ### onNodeAdded
@@ -92,6 +92,22 @@ Used to create a new node. Only works on `editable` mode. To trigger the new nod
 { title: String, x: Number, y: Number}
 ```
 Where `x` and `y` are the coords where the user double clicked.
+
+### onNodeRemoved
+
+> `function(nodes: Array)` | defaults to: `noOp`
+
+Used to remove selected node. On `editable` mode, click on a node opens a _panel_ for trigger specific component actions, ie: remove element, add edge, etc. 
+
+When remove-node-action is executed this cb function will be called with a copy of input `nodes` **excluding** selected node.
+
+### onEdgeRemoved
+
+> `function(edges: Array)` | defaults to `noOp`
+
+Used to remove selected edge. On `editable` mode, click on an edge opens a _panel_ for trigger specific component actions, ie: remove element, etc.
+
+When remove-edge-action is executed this cb function will be called with a copy of input `edges` **excluding** selected edge.
 
 ## FAQs
 

--- a/packages/dag/src/dag.js
+++ b/packages/dag/src/dag.js
@@ -4,11 +4,12 @@ import { zoom } from 'd3-zoom';
 import { forceSimulation, forceCollide, forceCenter, forceLink } from 'd3-force';
 
 export const DEFAULTS = {
-  selectedClass: 'selected',
-  linkClass: 'connect-node',
-  nodeClass: 'node',
-  graphClass: 'graph',
-  activeEditId: 'active-editing',
+  selectedNodeClass: 'dag__node-selected',
+  selectedEdgeClass: 'dag__edge-selected',
+  linkClass: 'dag__edge',
+  nodeClass: 'dag__node',
+  graphClass: 'dag__graph',
+  arrowClass: 'dag__edge-arrow',
   BACKSPACE_KEY: 8,
   DELETE_KEY: 46,
   ENTER_KEY: 13,
@@ -40,6 +41,7 @@ export default class DagCore {
   static DEFAULTS = DEFAULTS;
 
   constructor(root, initialState) {
+    // root represents the svg element. It is required.
     this.state = {
       dragEnable: initialState.dragEnable || true,
       zoomEnable: initialState.zoomEnable || false,
@@ -65,7 +67,6 @@ export default class DagCore {
       .attr('orient', 'auto');
 
     this.svg = select(`.${DEFAULTS.graphClass}`);
-
     this.simulation = forceSimulation(nodes)
       .force('charge', null)
       .force(
@@ -98,18 +99,18 @@ export default class DagCore {
   }
 
   updateGraph() {
+    const { nodeRadius } = this.state;
+    // add arrow heads using a polygon
+    selectAll(`.${DEFAULTS.arrowClass}`).each(function() {
+      const line = this.parentNode.querySelector('line');
+      createArrow(this, line, nodeRadius);
+    });
+
     selectAll('line')
       .attr('x1', d => d.source.x)
       .attr('y1', d => d.source.y)
       .attr('x2', d => d.target.x)
       .attr('y2', d => d.target.y);
-
-    const nodeRadius = this.state.nodeRadius;
-    // add arrow heads using a polygon
-    selectAll('.dag__edge-arrow').each(function() {
-      const line = this.parentNode.querySelector('line');
-      createArrow(this, line, nodeRadius);
-    });
 
     selectAll(`.${DagCore.DEFAULTS.nodeClass}`).attr('transform', d => `translate(${d.x}, ${d.y})`);
   }

--- a/packages/dag/src/dag.js
+++ b/packages/dag/src/dag.js
@@ -1,7 +1,7 @@
 import { select, selectAll, event } from 'd3-selection';
 import { drag } from 'd3-drag';
 import { zoom } from 'd3-zoom';
-import { forceSimulation, forceCollide, forceManyBody, forceCenter, forceY, forceX, forceLink } from 'd3-force';
+import { forceSimulation, forceCollide, forceCenter, forceLink } from 'd3-force';
 
 export const DEFAULTS = {
   selectedClass: 'selected',
@@ -15,13 +15,35 @@ export const DEFAULTS = {
   nodeRadius: 50
 };
 
+const createArrow = (arrow, line, nodeRadius) => {
+  const triangleSize = 10;
+
+  const totalLength = line.getTotalLength() - (nodeRadius + 11.5); // yes, 11.5 is a magic number
+  const startPoint = line.getPointAtLength(totalLength - triangleSize);
+  const endPoint = line.getPointAtLength(totalLength);
+
+  const angle = Math.atan2(endPoint.y - startPoint.y, endPoint.x - startPoint.x);
+  const angleDeg = (angle * 180) / Math.PI;
+
+  const pointOnCircle = (p, a, d) => {
+    const newAngle = ((a + d) * Math.PI) / 180;
+    return p.x + Math.cos(newAngle) * triangleSize + ',' + (p.y + Math.sin(newAngle) * triangleSize);
+  };
+
+  const p1 = pointOnCircle(endPoint, angleDeg, 0);
+  const p2 = pointOnCircle(endPoint, angleDeg, 135);
+  const p3 = pointOnCircle(endPoint, angleDeg, -135);
+  arrow.setAttribute('points', `${p1} ${p2} ${p3}`);
+};
+
 export default class DagCore {
   static DEFAULTS = DEFAULTS;
 
   constructor(root, initialState) {
     this.state = {
       dragEnable: initialState.dragEnable || true,
-      zoomEnable: initialState.zoomEnable || false
+      zoomEnable: initialState.zoomEnable || false,
+      nodeRadius: initialState.nodeRadius
     };
 
     this.d3root = root;
@@ -32,52 +54,31 @@ export default class DagCore {
       height: initialState.height,
       nodes: initialState.nodes,
       edges: initialState.edges,
-      theme: initialState.classes.dagEdgeMarker
+      theme: initialState.classes.dagEdgeMarker,
+      nodeRadius: initialState.nodeRadius
     });
   }
 
-  createGraph({ root, width, height, nodes, edges, theme }) {
+  createGraph({ root, width, height, nodes, edges, theme, nodeRadius }) {
     select(root)
-      .append('svg:defs')
-      .selectAll('marker')
-      .data(['end'])
-      .enter()
-      .append('svg:marker') // This section adds in the arrows
-      .attr('id', String)
-      .attr('viewBox', '0 -5 10 10')
-      .attr('refX', 72) // refx distanche ~= node radius
-      .attr('refY', 0)
-      .attr('markerWidth', 8) //6
-      .attr('markerHeight', 8) //6
-      .attr('markerUnits', 'userSpaceOnUse')
       .attr('class', theme)
-      .attr('orient', 'auto')
-      .append('svg:path')
-      .attr('d', 'M0,-5L10,0L0,5');
+      .attr('orient', 'auto');
 
     this.svg = select(`.${DEFAULTS.graphClass}`);
 
     this.simulation = forceSimulation(nodes)
-      .force('charge', forceManyBody())
+      .force('charge', null)
       .force(
         'link',
         forceLink(edges).id(function(d) {
           return d.title;
         })
       )
-      .force(
-        'collide',
-        forceCollide(function(d) {
-          return 80;
-        })
-      )
-      .force('center', forceCenter(width / 2, height / 2))
-      .force('y', forceY(0))
-      .force('x', forceX(0));
+      .force('collide', forceCollide(() => 80))
+      .force('center', forceCenter(width / 2, height / 2));
 
     this.setZoomMode();
     this.setDragMode();
-
     this.simulation.on('tick', () => this.updateGraph());
   }
 
@@ -102,6 +103,13 @@ export default class DagCore {
       .attr('y1', d => d.source.y)
       .attr('x2', d => d.target.x)
       .attr('y2', d => d.target.y);
+
+    const nodeRadius = this.state.nodeRadius;
+    // add arrow heads using a polygon
+    selectAll('.dag__edge-arrow').each(function() {
+      const line = this.parentNode.querySelector('line');
+      createArrow(this, line, nodeRadius);
+    });
 
     selectAll(`.${DagCore.DEFAULTS.nodeClass}`).attr('transform', d => `translate(${d.x}, ${d.y})`);
   }

--- a/packages/dag/src/dag.js
+++ b/packages/dag/src/dag.js
@@ -49,6 +49,7 @@ export default class DagCore {
       .attr('refY', 0)
       .attr('markerWidth', 8) //6
       .attr('markerHeight', 8) //6
+      .attr('markerUnits', 'userSpaceOnUse')
       .attr('class', theme)
       .attr('orient', 'auto')
       .append('svg:path')

--- a/packages/dag/src/edge.js
+++ b/packages/dag/src/edge.js
@@ -47,7 +47,10 @@ export default class Edge extends Component {
     const { editable, data, editSelectedEdge, onEdgeClick, idx } = this.props;
 
     if (editable) {
-      return editSelectedEdge(Object.assign({}, data, { idx }));
+      return editSelectedEdge({
+        ...data,
+        idx
+      });
     }
 
     onEdgeClick({
@@ -55,7 +58,9 @@ export default class Edge extends Component {
       target: data.target.title
     });
     // add selected state
-    this.setState({ selected: !this.state.selected });
+    this.setState(prevState => ({
+      selected: !prevState.selected
+    }));
   };
 
   deleteAction(event) {

--- a/packages/dag/src/edge.js
+++ b/packages/dag/src/edge.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import classNames from 'classnames';
 import { select, selectAll } from 'd3-selection';
+
 import { DEFAULTS } from './dag';
 
 const enterEdge = (selection, ghostEdge) => {
@@ -38,22 +39,35 @@ export default class Edge extends Component {
   }
 
   handleEdgeClick = e => {
-    this.props.onEdgeClick(e);
+    const { editable, data, editSelectedEdge, idx } = this.props;
+
+    if (editable) {
+      editSelectedEdge(Object.assign({}, data, { idx }));
+    }
+    this.props.onEdgeClick(e, data);
   };
 
   render() {
     // TODO (dk): apply classes.dagEdgeMarker class to marker-end (arrow)
-    const { classes, ghostEdge } = this.props;
+    const { classes, ghostEdge, children, data, showEdgePanel, showEdgePanelIdx, idx } = this.props;
     const edgeClasses = [classes.dagEdge];
+
     if (ghostEdge) {
       edgeClasses.push(classes.dagEdgeGhost);
     }
+
+    if (showEdgePanelIdx === idx) {
+      edgeClasses.push(classes.dagEdgeEditable);
+    }
+
     return (
       <line
         ref={node => (this.node = node)}
         className={classNames(DEFAULTS.linkClass, edgeClasses)}
         onClick={this.handleEdgeClick}
-      />
+      >
+        {showEdgePanel && showEdgePanelIdx === idx && children && children({ data })}
+      </line>
     );
   }
 }

--- a/packages/dag/src/edge.js
+++ b/packages/dag/src/edge.js
@@ -44,24 +44,28 @@ export default class Edge extends Component {
   }
 
   handleEdgeClick = e => {
-    const { editable, data, editSelectedEdge, idx } = this.props;
+    const { editable, data, editSelectedEdge, onEdgeClick, idx } = this.props;
 
     if (editable) {
-      editSelectedEdge(Object.assign({}, data, { idx }));
+      return editSelectedEdge(Object.assign({}, data, { idx }));
     }
 
-    this.props.onEdgeClick(data);
+    onEdgeClick({
+      source: data.source.title,
+      target: data.target.title
+    });
     // add selected state
     this.setState({ selected: !this.state.selected });
   };
 
-  deleteAction() {
-    this.props.deleteEdge(this.props.idx);
+  deleteAction(event) {
+    const { deleteEdge, idx } = this.props;
+    deleteEdge({ event, idx });
   }
 
   getActions() {
     return {
-      deleteAction: () => this.deleteAction()
+      deleteAction: event => this.deleteAction(event)
     };
   }
 

--- a/packages/dag/src/edge.js
+++ b/packages/dag/src/edge.js
@@ -27,6 +27,12 @@ export default class Edge extends Component {
     onEdgeClick: () => {}
   };
 
+  constructor(props) {
+    super(props);
+    this.state = {
+      selected: false
+    };
+  }
   componentDidMount() {
     this.d3Edge = select(this.edge)
       .datum(this.props.data)
@@ -43,12 +49,34 @@ export default class Edge extends Component {
     if (editable) {
       editSelectedEdge(Object.assign({}, data, { idx }));
     }
-    this.props.onEdgeClick(e, data);
+
+    this.props.onEdgeClick(data);
+    // add selected state
+    this.setState({ selected: !this.state.selected });
   };
 
+  deleteAction() {
+    this.props.deleteEdge(this.props.idx);
+  }
+
+  getActions() {
+    return {
+      deleteAction: () => this.deleteAction()
+    };
+  }
+
   render() {
-    // TODO (dk): apply classes.dagEdgeMarker class to marker-end (arrow)
-    const { classes, editable, ghostEdge, children, data, showEdgePanel, showEdgePanelIdx, idx } = this.props;
+    const {
+      classes,
+      editable,
+      ghostEdge,
+      children,
+      data,
+      showEdgePanel,
+      showEdgePanelIdx,
+      idx,
+      selectedClass
+    } = this.props;
     const edgeClasses = [classes.dagEdge];
 
     if (ghostEdge) {
@@ -59,12 +87,16 @@ export default class Edge extends Component {
       edgeClasses.push(classes.dagEditable);
     }
 
+    if (this.state.selected) {
+      // TODO(dk): clear other selected eddges (allow multiple selection?)
+      edgeClasses.push(selectedClass);
+    }
     return (
-      <g className={classNames(DEFAULTS.linkClass, edgeClasses)}>
-        <line ref={edge => (this.edge = edge)} onClick={this.handleEdgeClick}>
-          {showEdgePanel && showEdgePanelIdx === idx && children && children({ data })}
+      <g className={classNames(DEFAULTS.linkClass, edgeClasses)} onClick={this.handleEdgeClick}>
+        <line ref={edge => (this.edge = edge)}>
+          {showEdgePanel && showEdgePanelIdx === idx && children && children({ ...data, actions: this.getActions() })}
         </line>
-        {ghostEdge ? '' : <polygon className="dag__edge-arrow" />}
+        {ghostEdge ? '' : <polygon className={DEFAULTS.arrowClass} />}
       </g>
     );
   }

--- a/packages/dag/src/edge.js
+++ b/packages/dag/src/edge.js
@@ -5,14 +5,12 @@ import { select, selectAll } from 'd3-selection';
 import { DEFAULTS } from './dag';
 
 const enterEdge = (selection, ghostEdge) => {
-  selection.attr('stroke-width', 1).attr('marker-end', 'url(#end)');
   if (ghostEdge) {
     // Note (dk): ghostEdge mode refers to an extra edge which appears
     // when you try to connect two nodes while in editable mode.
     selectAll(`.${DEFAULTS.nodeClass}`).each(function() {
       this.parentNode.appendChild(this);
     });
-    selection.attr('stroke-width', 1).attr('marker-end', '');
   }
 };
 
@@ -28,8 +26,9 @@ export default class Edge extends Component {
   static defaultProps = {
     onEdgeClick: () => {}
   };
+
   componentDidMount() {
-    this.d3Edge = select(this.node)
+    this.d3Edge = select(this.edge)
       .datum(this.props.data)
       .call(selection => enterEdge(selection, this.props.ghostEdge));
   }
@@ -49,25 +48,24 @@ export default class Edge extends Component {
 
   render() {
     // TODO (dk): apply classes.dagEdgeMarker class to marker-end (arrow)
-    const { classes, ghostEdge, children, data, showEdgePanel, showEdgePanelIdx, idx } = this.props;
+    const { classes, editable, ghostEdge, children, data, showEdgePanel, showEdgePanelIdx, idx } = this.props;
     const edgeClasses = [classes.dagEdge];
 
     if (ghostEdge) {
       edgeClasses.push(classes.dagEdgeGhost);
     }
 
-    if (showEdgePanelIdx === idx) {
-      edgeClasses.push(classes.dagEdgeEditable);
+    if (editable) {
+      edgeClasses.push(classes.dagEditable);
     }
 
     return (
-      <line
-        ref={node => (this.node = node)}
-        className={classNames(DEFAULTS.linkClass, edgeClasses)}
-        onClick={this.handleEdgeClick}
-      >
-        {showEdgePanel && showEdgePanelIdx === idx && children && children({ data })}
-      </line>
+      <g className={classNames(DEFAULTS.linkClass, edgeClasses)}>
+        <line ref={edge => (this.edge = edge)} onClick={this.handleEdgeClick}>
+          {showEdgePanel && showEdgePanelIdx === idx && children && children({ data })}
+        </line>
+        {ghostEdge ? '' : <polygon className="dag__edge-arrow" />}
+      </g>
     );
   }
 }

--- a/packages/dag/src/index.js
+++ b/packages/dag/src/index.js
@@ -98,7 +98,7 @@ class Dag extends Component {
     selectedNodeClass: DEFAULTS.selectedNodeClass,
     onNodeAdded: () => {},
     onEdgeAdded: () => {},
-    onDeleteEdge: () => {},
+    onEdgeRemoved: () => {},
     nodes: [],
     edges: []
   };
@@ -301,7 +301,7 @@ class Dag extends Component {
 
   // GRAPH ACTIONS
   deleteEdge(idx) {
-    const { onDeleteEdge, edges } = this.props;
+    const { onEdgeRemoved, edges } = this.props;
     // remove edge from this.props.edges (copy)
     let start = 0;
     let pivotA = 1;
@@ -318,7 +318,7 @@ class Dag extends Component {
     }
     const newEdges = edges.slice(start, pivotA).concat(edges.slice(pivotB, end));
 
-    onDeleteEdge(newEdges);
+    onEdgeRemoved(newEdges);
   }
 
   render() {

--- a/packages/dag/src/index.js
+++ b/packages/dag/src/index.js
@@ -90,6 +90,24 @@ class SvgTextInput extends Component {
   }
 }
 
+// \\ default render method for edge actions \\
+const dagRenderEdgeActions = ({ deleteAction }) => (
+  <IconButton>
+    <DeleteIcon onClick={deleteAction} />
+  </IconButton>
+);
+
+const dagRenderNodeActions = ({ deleteAction, createEdgeAction }) => (
+  <React.Fragment>
+    <IconButton>
+      <DeleteIcon onClick={deleteAction} />
+    </IconButton>
+    <IconButton>
+      <MultilineIcon onClick={createEdgeAction} />
+    </IconButton>
+  </React.Fragment>
+);
+
 class Dag extends Component {
   static displayName = 'Dag';
   static defaultProps = {
@@ -102,7 +120,9 @@ class Dag extends Component {
     onEdgeRemoved: () => {},
     onNodeRemoved: () => {},
     nodes: [],
-    edges: []
+    edges: [],
+    renderNodeActions: dagRenderNodeActions,
+    renderEdgeActions: dagRenderEdgeActions
   };
 
   constructor(props) {
@@ -267,13 +287,13 @@ class Dag extends Component {
   };
 
   newNode = e => {
-    this.setState({
-      newNodeReady: !this.state.newNodeReady,
+    this.setState(prevState => ({
+      newNodeReady: !prevState.newNodeReady,
       newNode: {
         x: e.clientX,
         y: e.clientY
       }
-    });
+    }));
     this.dagcore.toggleDrag();
   };
 
@@ -323,11 +343,7 @@ class Dag extends Component {
         target={target.title}
         actions={actions}
       >
-        {({ deleteAction }) => (
-          <IconButton>
-            <DeleteIcon onClick={deleteAction} />
-          </IconButton>
-        )}
+        {this.props.renderEdgeActions}
       </GraphPanel>
     );
   };
@@ -344,16 +360,7 @@ class Dag extends Component {
         title={title}
         actions={actions}
       >
-        {({ deleteAction, createEdgeAction }) => (
-          <React.Fragment>
-            <IconButton>
-              <DeleteIcon onClick={deleteAction} />
-            </IconButton>
-            <IconButton>
-              <MultilineIcon onClick={createEdgeAction} />
-            </IconButton>
-          </React.Fragment>
-        )}
+        {this.props.renderNodeActions}
       </GraphPanel>
     );
   };

--- a/packages/dag/src/index.js
+++ b/packages/dag/src/index.js
@@ -286,13 +286,14 @@ class Dag extends Component {
   };
 
   render() {
-    const { width, height, classes = {}, editable, onNodeClick, onEdgeClick } = this.props;
+    const { width, height, classes = {}, editable, onNodeClick, onEdgeClick, nodeRadius } = this.props;
     const rootClasses = [classes.root];
 
     // NODES
     const nodes = this.props.nodes.map((node, i) => {
       return (
         <Node
+          nodeRadius={nodeRadius}
           data={node}
           name={node.title}
           key={`node-${i}`}
@@ -339,6 +340,7 @@ class Dag extends Component {
             {nodes}
             {this.state.newNodeReady && (
               <Node
+                nodeRadius={nodeRadius}
                 data={{ id: undefined, x: this.state.newNode.x, y: this.state.newNode.y }}
                 name={''}
                 classes={this.props.classes}

--- a/packages/dag/src/index.js
+++ b/packages/dag/src/index.js
@@ -20,6 +20,8 @@ const styles = theme => ({
   dagNode: {
     stroke: theme.palette.type === 'light' ? theme.palette.primary.light : theme.palette.secondary.dark,
     fill: theme.palette.background.default,
+    transition: 'stroke-width 0.3s ease-in',
+    strokeWidth: 2,
     '&:hover': {
       backgroundColor: theme.palette.action.hover
     }
@@ -34,9 +36,11 @@ const styles = theme => ({
   dagEdge: {
     stroke: theme.palette.secondary[theme.palette.type],
     transition: 'stroke-width 0.3s ease-in',
-    strokeWidth: 1,
+    strokeWidth: 2
+  },
+  dagEditable: {
     '&:hover': {
-      strokeWidth: 3
+      strokeWidth: 4
     }
   },
   dagEdgeMarker: {
@@ -88,6 +92,7 @@ class SvgTextInput extends Component {
 class Dag extends Component {
   static displayName = 'Dag';
   static defaultProps = {
+    nodeRadius: 50,
     editable: false,
     onNodeAdded: () => {},
     onEdgeAdded: () => {}
@@ -118,9 +123,8 @@ class Dag extends Component {
     });
   }
 
-  createGraph = ({ root, nodes, edges, width, height, classes }) => {
-    this.dagcore = new DagCore(root, { nodes, edges, width, height, classes });
-    this.dagcore.simulation.on('tick', this.dagcore.updateGraph);
+  createGraph = ({ root, nodes, edges, width, height, classes, nodeRadius }) => {
+    this.dagcore = new DagCore(root, { nodes, edges, width, height, classes, nodeRadius });
   };
 
   componentDidMount() {

--- a/packages/dag/src/node.js
+++ b/packages/dag/src/node.js
@@ -39,8 +39,8 @@ export default class Node extends Component {
     onNodeAdded: () => {}
   };
 
-  constructor(args) {
-    super(...args);
+  constructor(props) {
+    super(props);
     this.state = {
       labelX: 0,
       labelY: 0,
@@ -73,18 +73,19 @@ export default class Node extends Component {
   };
 
   handleNodeClick = e => {
-    const { editable, editSelectedNode, onNodeClick } = this.props;
+    const { editable, editSelectedNode, onNodeClick, data, idx, name } = this.props;
     const node = {
-      title: this.props.name,
-      x: this.props.data.x,
-      y: this.props.data.y
+      title: name,
+      x: data.x,
+      y: data.y,
+      idx: idx
     };
 
     if (editable) {
-      editSelectedNode(node);
+      return editSelectedNode(node);
     }
 
-    onNodeClick(node);
+    onNodeClick({ title: name });
     // add selected state
     this.setState({ selected: !this.state.selected });
   };
@@ -104,7 +105,7 @@ export default class Node extends Component {
         if (this.state.text) {
           this.props.onNodeAdded({
             ...this.props.data,
-            name: this.state.text
+            title: this.state.text
           });
         }
         this.props.closeNode();
@@ -118,8 +119,33 @@ export default class Node extends Component {
     }
   };
 
+  deleteAction(event) {
+    const { deleteNode, idx } = this.props;
+    deleteNode({ event, idx });
+  }
+
+  getActions() {
+    return {
+      deleteAction: event => this.deleteAction(event),
+      createEdgeAction: this.props.createEdge
+    };
+  }
+
   render() {
-    const { newNode, outerEl, classes, editable, name, selectedClass } = this.props;
+    const {
+      newNode,
+      outerEl,
+      classes,
+      editable,
+      name,
+      data,
+      selectedClass,
+      children,
+      nodePanel,
+      showPanel,
+      showPanelIdx,
+      idx
+    } = this.props;
 
     const nodeClasses = [classes.dagNode];
 
@@ -134,14 +160,14 @@ export default class Node extends Component {
     return (
       <g
         className={classNames(DEFAULTS.nodeClass, nodeClasses)}
-        onClick={e => this.handleNodeClick(e, this.name)}
+        onClick={this.handleNodeClick}
         ref={node => (this.node = node)}
         id={`dag__node--${name}`}
       >
         <circle />
         <text ref={node => (this.label = node)} className={classes.dagNodeText} />
         {newNode &&
-          this.props.children({
+          children({
             outerEl,
             onTextChange: this.onTextChange,
             onKeyDown: this.onKeyDown,
@@ -151,6 +177,10 @@ export default class Node extends Component {
             labelWidth: this.state.labelWidth,
             labelHeight: this.state.labelHeight
           })}
+        {showPanel &&
+          showPanelIdx === idx &&
+          nodePanel &&
+          nodePanel({ outerEl, title: name, x: data.x, y: data.y, actions: this.getActions() })}
       </g>
     );
   }

--- a/packages/dag/src/node.js
+++ b/packages/dag/src/node.js
@@ -46,7 +46,8 @@ export default class Node extends Component {
       labelY: 0,
       labelWidth: '50px',
       labelHeight: '20px',
-      text: ''
+      text: '',
+      selected: false
     };
   }
 
@@ -84,6 +85,8 @@ export default class Node extends Component {
     }
 
     onNodeClick(node);
+    // add selected state
+    this.setState({ selected: !this.state.selected });
   };
 
   onTextChange = e => {
@@ -116,7 +119,7 @@ export default class Node extends Component {
   };
 
   render() {
-    const { newNode, outerEl, classes, editable } = this.props;
+    const { newNode, outerEl, classes, editable, name, selectedClass } = this.props;
 
     const nodeClasses = [classes.dagNode];
 
@@ -124,11 +127,16 @@ export default class Node extends Component {
       nodeClasses.push(classes.dagEditable);
     }
 
+    if (this.state.selected) {
+      // TODO(dk): clear other selected nodes (allow multiple selection?)
+      nodeClasses.push(selectedClass);
+    }
     return (
       <g
         className={classNames(DEFAULTS.nodeClass, nodeClasses)}
         onClick={e => this.handleNodeClick(e, this.name)}
         ref={node => (this.node = node)}
+        id={`dag__node--${name}`}
       >
         <circle />
         <text ref={node => (this.label = node)} className={classes.dagNodeText} />

--- a/packages/dag/src/node.js
+++ b/packages/dag/src/node.js
@@ -73,17 +73,18 @@ export default class Node extends Component {
   };
 
   handleNodeClick = e => {
+    const { editable, editSelectedNode, onNodeClick } = this.props;
     const node = {
       title: this.props.name,
       x: this.props.data.x,
       y: this.props.data.y
     };
 
-    if (this.props.editable) {
-      this.props.editSelectedNode(node);
+    if (editable) {
+      editSelectedNode(node);
     }
 
-    this.props.onNodeClick(node);
+    onNodeClick(node);
   };
 
   onTextChange = e => {

--- a/packages/dag/src/node.js
+++ b/packages/dag/src/node.js
@@ -87,7 +87,7 @@ export default class Node extends Component {
 
     onNodeClick({ title: name });
     // add selected state
-    this.setState({ selected: !this.state.selected });
+    this.setState(prevState => ({ selected: !prevState.selected }));
   };
 
   onTextChange = e => {

--- a/packages/dag/src/node.js
+++ b/packages/dag/src/node.js
@@ -3,11 +3,9 @@ import classNames from 'classnames';
 import { select } from 'd3-selection';
 import { DEFAULTS } from './dag';
 
-const DEFAULT_RADIUS = 50;
-
 const enterNode = (selection, props) => {
   selection.select('circle').attr('r', d => {
-    return props.radius || DEFAULT_RADIUS;
+    return props.nodeRadius;
   });
 
   insertTitleLinebreaks(selection, props.name);
@@ -24,6 +22,7 @@ const insertTitleLinebreaks = (gEl, title) => {
   const el = gEl
     .select('text')
     .attr('text-anchor', 'middle')
+    .attr('stroke-width', 1)
     .attr('dy', `-${(nwords - 1) * 7.5}`);
 
   words.forEach((word, idx) => {
@@ -99,10 +98,12 @@ export default class Node extends Component {
     switch (keyCode) {
       case 13:
         // enter key
-        this.props.onNodeAdded({
-          ...this.props.data,
-          name: this.state.text
-        });
+        if (this.state.text) {
+          this.props.onNodeAdded({
+            ...this.props.data,
+            name: this.state.text
+          });
+        }
         this.props.closeNode();
         break;
       case 27:
@@ -115,16 +116,22 @@ export default class Node extends Component {
   };
 
   render() {
-    const { newNode, outerEl } = this.props;
+    const { newNode, outerEl, classes, editable } = this.props;
+
+    const nodeClasses = [classes.dagNode];
+
+    if (editable) {
+      nodeClasses.push(classes.dagEditable);
+    }
 
     return (
       <g
-        className={classNames(DEFAULTS.nodeClass, this.props.classes.dagNode)}
+        className={classNames(DEFAULTS.nodeClass, nodeClasses)}
         onClick={e => this.handleNodeClick(e, this.name)}
         ref={node => (this.node = node)}
       >
         <circle />
-        <text ref={node => (this.label = node)} className={this.props.classes.dagNodeText} />
+        <text ref={node => (this.label = node)} className={classes.dagNodeText} />
         {newNode &&
           this.props.children({
             outerEl,

--- a/packages/dag/src/panel.js
+++ b/packages/dag/src/panel.js
@@ -7,7 +7,8 @@ import Typography from '@material-ui/core/Typography';
 
 const styles = theme => ({
   card: {
-    display: 'flex'
+    display: 'flex',
+    position: 'absolute'
   },
   details: {
     display: 'flex',
@@ -30,8 +31,10 @@ class GraphPanel extends Component {
     this.el = document.createElement('div');
   }
   componentDidMount() {
-    //this.props.outerEl.appendChild(this.el);
-    document.body.appendChild(this.el)
+    // FIXME(dk): we should use the outerEl (div wrapping graph)
+    // instead of adding a random div to the body.
+    // this.props.outerEl.appendChild(this.el);
+    document.body.appendChild(this.el);
     if (this.panel) this.panel.focus();
   }
 
@@ -54,25 +57,21 @@ class GraphPanel extends Component {
     return (
       <React.Fragment>
         <div>
-          <Typography variant="body1">Source:</Typography>
-          <Typography variant="body1" color="textSecondary">
-            {source}
-          </Typography>
+          <Typography variant="caption">Source</Typography>
+          <Typography variant="body1">{source}</Typography>
         </div>
         <div>
-          <Typography variant="body1">Target:</Typography>
-          <Typography variant="body1" color="textSecondary">
-            {target}
-          </Typography>
+          <Typography variant="caption">Target</Typography>
+          <Typography variant="body1">{target}</Typography>
         </div>
       </React.Fragment>
     );
   }
 
   render() {
-    const { children, classes, title, source, target } = this.props;
+    const { children, classes, title, source, target, style } = this.props;
     return createPortal(
-      <Card className={classes.panel}>
+      <Card className={classes.panel} style={style}>
         <div className={classes.details}>
           <CardContent className={classes.content}>
             {title ? this.renderContentNode({ title }) : this.renderContentEdge({ source, target })}

--- a/packages/dag/src/panel.js
+++ b/packages/dag/src/panel.js
@@ -19,6 +19,7 @@ const styles = theme => ({
   },
   controls: {
     alignItems: 'center',
+    paddingTop: theme.spacing.unit,
     paddingLeft: theme.spacing.unit,
     paddingBottom: theme.spacing.unit
   }
@@ -30,24 +31,21 @@ class GraphPanel extends Component {
     this.el = document.createElement('div');
   }
   componentDidMount() {
-    // FIXME(dk): we should use the outerEl (div wrapping graph)
-    // instead of adding a random div to the body.
-    // this.props.outerEl.appendChild(this.el);
-    document.body.appendChild(this.el);
+    this.props.outerEl.appendChild(this.el);
     if (this.panel) this.panel.focus();
   }
 
   componentWillUnmount() {
-    document.body.removeChild(this.el);
+    this.props.outerEl.removeChild(this.el);
   }
 
   renderContentNode({ title }) {
     return (
       <Grid item xs={12}>
-        <Typography variant="body1" color="default">
-          Node:
+        <Typography variant="caption" color="default">
+          Node
         </Typography>
-        <Typography variant="body1" color="inherit">
+        <Typography variant="body2" color="inherit">
           {title}
         </Typography>
       </Grid>

--- a/packages/dag/src/panel.js
+++ b/packages/dag/src/panel.js
@@ -1,0 +1,88 @@
+import React, { Component } from 'react';
+import { createPortal } from 'react-dom';
+import { withStyles } from '@material-ui/core/styles';
+import Card from '@material-ui/core/Card';
+import CardContent from '@material-ui/core/CardContent';
+import Typography from '@material-ui/core/Typography';
+
+const styles = theme => ({
+  card: {
+    display: 'flex'
+  },
+  details: {
+    display: 'flex',
+    flexDirection: 'column'
+  },
+  content: {
+    flex: '1 0 auto'
+  },
+  controls: {
+    display: 'flex',
+    alignItems: 'center',
+    paddingLeft: theme.spacing.unit,
+    paddingBottom: theme.spacing.unit
+  }
+});
+
+class GraphPanel extends Component {
+  constructor(props) {
+    super(props);
+    this.el = document.createElement('div');
+  }
+  componentDidMount() {
+    //this.props.outerEl.appendChild(this.el);
+    document.body.appendChild(this.el)
+    if (this.panel) this.panel.focus();
+  }
+
+  componentWillUnmount() {
+    document.body.removeChild(this.el);
+  }
+
+  renderContentNode({ title }) {
+    return (
+      <React.Fragment>
+        <Typography variant="body1">Node:</Typography>
+        <Typography variant="body1" color="textSecondary">
+          {title}
+        </Typography>
+      </React.Fragment>
+    );
+  }
+
+  renderContentEdge({ source, target }) {
+    return (
+      <React.Fragment>
+        <div>
+          <Typography variant="body1">Source:</Typography>
+          <Typography variant="body1" color="textSecondary">
+            {source}
+          </Typography>
+        </div>
+        <div>
+          <Typography variant="body1">Target:</Typography>
+          <Typography variant="body1" color="textSecondary">
+            {target}
+          </Typography>
+        </div>
+      </React.Fragment>
+    );
+  }
+
+  render() {
+    const { children, classes, title, source, target } = this.props;
+    return createPortal(
+      <Card className={classes.panel}>
+        <div className={classes.details}>
+          <CardContent className={classes.content}>
+            {title ? this.renderContentNode({ title }) : this.renderContentEdge({ source, target })}
+          </CardContent>
+        </div>
+        <div className={classes.controls}>{children && children()}</div>
+      </Card>,
+      this.el
+    );
+  }
+}
+
+export default withStyles(styles, { withTheme: true })(GraphPanel);

--- a/packages/dag/src/panel.js
+++ b/packages/dag/src/panel.js
@@ -4,21 +4,20 @@ import { withStyles } from '@material-ui/core/styles';
 import Card from '@material-ui/core/Card';
 import CardContent from '@material-ui/core/CardContent';
 import Typography from '@material-ui/core/Typography';
+import Grid from '@material-ui/core/Grid';
 
 const styles = theme => ({
   card: {
-    display: 'flex',
     position: 'absolute'
   },
   details: {
-    display: 'flex',
-    flexDirection: 'column'
+    backgroundColor: theme.palette.primary[theme.palette.type],
+    color: theme.palette.background.default
   },
   content: {
     flex: '1 0 auto'
   },
   controls: {
-    display: 'flex',
     alignItems: 'center',
     paddingLeft: theme.spacing.unit,
     paddingBottom: theme.spacing.unit
@@ -44,40 +43,55 @@ class GraphPanel extends Component {
 
   renderContentNode({ title }) {
     return (
-      <React.Fragment>
-        <Typography variant="body1">Node:</Typography>
-        <Typography variant="body1" color="textSecondary">
+      <Grid item xs={12}>
+        <Typography variant="body1" color="default">
+          Node:
+        </Typography>
+        <Typography variant="body1" color="inherit">
           {title}
         </Typography>
-      </React.Fragment>
+      </Grid>
     );
   }
 
   renderContentEdge({ source, target }) {
     return (
-      <React.Fragment>
-        <div>
-          <Typography variant="caption">Source</Typography>
-          <Typography variant="body1">{source}</Typography>
-        </div>
-        <div>
-          <Typography variant="caption">Target</Typography>
-          <Typography variant="body1">{target}</Typography>
-        </div>
-      </React.Fragment>
+      <Grid container>
+        <Grid item xs={12} md={6}>
+          <Typography variant="caption" color="default">
+            Source
+          </Typography>
+          <Typography variant="body2" color="inherit">
+            {source}
+          </Typography>
+        </Grid>
+        <Grid item xs={12} md={6}>
+          <Typography variant="caption" color="default">
+            Target
+          </Typography>
+          <Typography variant="body2" color="inherit">
+            {target}
+          </Typography>
+        </Grid>
+      </Grid>
     );
   }
 
   render() {
-    const { children, classes, title, source, target, style } = this.props;
+    const { children, classes, title, source, target, style, actions = {} } = this.props;
+
     return createPortal(
       <Card className={classes.panel} style={style}>
-        <div className={classes.details}>
-          <CardContent className={classes.content}>
-            {title ? this.renderContentNode({ title }) : this.renderContentEdge({ source, target })}
-          </CardContent>
-        </div>
-        <div className={classes.controls}>{children && children()}</div>
+        <Grid item container alignItems="center">
+          <Grid item xs={12} className={classes.details}>
+            <CardContent className={classes.content}>
+              {title ? this.renderContentNode({ title }) : this.renderContentEdge({ source, target })}
+            </CardContent>
+          </Grid>
+          <Grid item xs={12}>
+            <div className={classes.controls}>{children && children({ ...actions })}</div>
+          </Grid>
+        </Grid>
       </Card>,
       this.el
     );

--- a/packages/dag/stories/index.js
+++ b/packages/dag/stories/index.js
@@ -68,7 +68,7 @@ export default ({ storiesOf, action, forceReRender }) => {
           editable={true}
           onEdgeAdded={action('onEdgeAdded')}
           onNodeAdded={action('onNodeAdded')}
-          onDeleteEdge={action('onDeleteEdge')}
+          onEdgeRemoved={action('onEdgeRemoved')}
           onEdgeClick={action('onEdgeClick')}
           onNodeClick={action('onNodeClick')}
           {...getProps()}

--- a/packages/dag/stories/index.js
+++ b/packages/dag/stories/index.js
@@ -60,7 +60,14 @@ export default ({ storiesOf, action, forceReRender }) => {
   storiesOf('dag/basic', module)
     .add('no wrapper', () => {
       // TODO(dk): parse real pkg json deps.
-      return <Dag onClick={action('clicked')} {...getProps()} />;
+      return (
+        <Dag
+          onClick={action('clicked')}
+          onEdgeClick={action('onEdgeClick')}
+          onNodeClick={action('onNodeClick')}
+          {...getProps()}
+        />
+      );
     })
     .add('editable mode', () => {
       return (
@@ -69,8 +76,7 @@ export default ({ storiesOf, action, forceReRender }) => {
           onEdgeAdded={action('onEdgeAdded')}
           onNodeAdded={action('onNodeAdded')}
           onEdgeRemoved={action('onEdgeRemoved')}
-          onEdgeClick={action('onEdgeClick')}
-          onNodeClick={action('onNodeClick')}
+          onNodeRemoved={action('onNodeRemoved')}
           {...getProps()}
         />
       );

--- a/packages/dag/stories/index.js
+++ b/packages/dag/stories/index.js
@@ -64,7 +64,15 @@ export default ({ storiesOf, action, forceReRender }) => {
     })
     .add('editable mode', () => {
       return (
-        <Dag editable={true} onEdgeAdded={action('onEdgeAdded')} onNodeAdded={action('onNodeAdded')} {...getProps()} />
+        <Dag
+          editable={true}
+          onEdgeAdded={action('onEdgeAdded')}
+          onNodeAdded={action('onNodeAdded')}
+          onDeleteEdge={action('onDeleteEdge')}
+          onEdgeClick={action('onEdgeClick')}
+          onNodeClick={action('onNodeClick')}
+          {...getProps()}
+        />
       );
     });
 

--- a/packages/dag/test/__snapshots__/storyshot.test.js.snap
+++ b/packages/dag/test/__snapshots__/storyshot.test.js.snap
@@ -17,70 +17,65 @@ exports[`Storyshots dag/basic editable mode 1`] = `
     width={500}
   >
     <g
-      className="graph"
+      className="dag__graph"
     >
       <g
-        className="connect-node Dag-dagEdge-11 Dag-dagEditable-12"
+        className="dag__edge Dag-dagEdge-11 Dag-dagEditable-12"
+        onClick={[Function]}
       >
-        <line
-          onClick={[Function]}
-        />
+        <line />
         <polygon
           className="dag__edge-arrow"
         />
       </g>
       <g
-        className="connect-node Dag-dagEdge-11 Dag-dagEditable-12"
+        className="dag__edge Dag-dagEdge-11 Dag-dagEditable-12"
+        onClick={[Function]}
       >
-        <line
-          onClick={[Function]}
-        />
+        <line />
         <polygon
           className="dag__edge-arrow"
         />
       </g>
       <g
-        className="connect-node Dag-dagEdge-11 Dag-dagEditable-12"
+        className="dag__edge Dag-dagEdge-11 Dag-dagEditable-12"
+        onClick={[Function]}
       >
-        <line
-          onClick={[Function]}
-        />
+        <line />
         <polygon
           className="dag__edge-arrow"
         />
       </g>
       <g
-        className="connect-node Dag-dagEdge-11 Dag-dagEditable-12"
+        className="dag__edge Dag-dagEdge-11 Dag-dagEditable-12"
+        onClick={[Function]}
       >
-        <line
-          onClick={[Function]}
-        />
+        <line />
         <polygon
           className="dag__edge-arrow"
         />
       </g>
       <g
-        className="connect-node Dag-dagEdge-11 Dag-dagEditable-12"
+        className="dag__edge Dag-dagEdge-11 Dag-dagEditable-12"
+        onClick={[Function]}
       >
-        <line
-          onClick={[Function]}
-        />
+        <line />
         <polygon
           className="dag__edge-arrow"
         />
       </g>
       <g
-        className="connect-node Dag-dagEdge-11 Dag-dagEditable-12"
+        className="dag__edge Dag-dagEdge-11 Dag-dagEditable-12"
+        onClick={[Function]}
       >
-        <line
-          onClick={[Function]}
-        />
+        <line />
         <polygon
           className="dag__edge-arrow"
         />
       </g>
       <g
-        className="node Dag-dagNode-9 Dag-dagEditable-12"
+        className="dag__node Dag-dagNode-9 Dag-dagEditable-12"
+        id="dag__node--app"
         onClick={[Function]}
       >
         <circle />
@@ -89,7 +84,8 @@ exports[`Storyshots dag/basic editable mode 1`] = `
         />
       </g>
       <g
-        className="node Dag-dagNode-9 Dag-dagEditable-12"
+        className="dag__node Dag-dagNode-9 Dag-dagEditable-12"
+        id="dag__node--lodash"
         onClick={[Function]}
       >
         <circle />
@@ -98,7 +94,8 @@ exports[`Storyshots dag/basic editable mode 1`] = `
         />
       </g>
       <g
-        className="node Dag-dagNode-9 Dag-dagEditable-12"
+        className="dag__node Dag-dagNode-9 Dag-dagEditable-12"
+        id="dag__node--react"
         onClick={[Function]}
       >
         <circle />
@@ -107,7 +104,8 @@ exports[`Storyshots dag/basic editable mode 1`] = `
         />
       </g>
       <g
-        className="node Dag-dagNode-9 Dag-dagEditable-12"
+        className="dag__node Dag-dagNode-9 Dag-dagEditable-12"
+        id="dag__node--react-dom"
         onClick={[Function]}
       >
         <circle />
@@ -116,7 +114,8 @@ exports[`Storyshots dag/basic editable mode 1`] = `
         />
       </g>
       <g
-        className="node Dag-dagNode-9 Dag-dagEditable-12"
+        className="dag__node Dag-dagNode-9 Dag-dagEditable-12"
+        id="dag__node--apollo"
         onClick={[Function]}
       >
         <circle />
@@ -125,7 +124,8 @@ exports[`Storyshots dag/basic editable mode 1`] = `
         />
       </g>
       <g
-        className="node Dag-dagNode-9 Dag-dagEditable-12"
+        className="dag__node Dag-dagNode-9 Dag-dagEditable-12"
+        id="dag__node--enzyme"
         onClick={[Function]}
       >
         <circle />
@@ -155,70 +155,65 @@ exports[`Storyshots dag/basic no wrapper 1`] = `
     width={500}
   >
     <g
-      className="graph"
+      className="dag__graph"
     >
       <g
-        className="connect-node Dag-dagEdge-4"
+        className="dag__edge Dag-dagEdge-4"
+        onClick={[Function]}
       >
-        <line
-          onClick={[Function]}
-        />
+        <line />
         <polygon
           className="dag__edge-arrow"
         />
       </g>
       <g
-        className="connect-node Dag-dagEdge-4"
+        className="dag__edge Dag-dagEdge-4"
+        onClick={[Function]}
       >
-        <line
-          onClick={[Function]}
-        />
+        <line />
         <polygon
           className="dag__edge-arrow"
         />
       </g>
       <g
-        className="connect-node Dag-dagEdge-4"
+        className="dag__edge Dag-dagEdge-4"
+        onClick={[Function]}
       >
-        <line
-          onClick={[Function]}
-        />
+        <line />
         <polygon
           className="dag__edge-arrow"
         />
       </g>
       <g
-        className="connect-node Dag-dagEdge-4"
+        className="dag__edge Dag-dagEdge-4"
+        onClick={[Function]}
       >
-        <line
-          onClick={[Function]}
-        />
+        <line />
         <polygon
           className="dag__edge-arrow"
         />
       </g>
       <g
-        className="connect-node Dag-dagEdge-4"
+        className="dag__edge Dag-dagEdge-4"
+        onClick={[Function]}
       >
-        <line
-          onClick={[Function]}
-        />
+        <line />
         <polygon
           className="dag__edge-arrow"
         />
       </g>
       <g
-        className="connect-node Dag-dagEdge-4"
+        className="dag__edge Dag-dagEdge-4"
+        onClick={[Function]}
       >
-        <line
-          onClick={[Function]}
-        />
+        <line />
         <polygon
           className="dag__edge-arrow"
         />
       </g>
       <g
-        className="node Dag-dagNode-2"
+        className="dag__node Dag-dagNode-2"
+        id="dag__node--app"
         onClick={[Function]}
       >
         <circle />
@@ -227,7 +222,8 @@ exports[`Storyshots dag/basic no wrapper 1`] = `
         />
       </g>
       <g
-        className="node Dag-dagNode-2"
+        className="dag__node Dag-dagNode-2"
+        id="dag__node--lodash"
         onClick={[Function]}
       >
         <circle />
@@ -236,7 +232,8 @@ exports[`Storyshots dag/basic no wrapper 1`] = `
         />
       </g>
       <g
-        className="node Dag-dagNode-2"
+        className="dag__node Dag-dagNode-2"
+        id="dag__node--react"
         onClick={[Function]}
       >
         <circle />
@@ -245,7 +242,8 @@ exports[`Storyshots dag/basic no wrapper 1`] = `
         />
       </g>
       <g
-        className="node Dag-dagNode-2"
+        className="dag__node Dag-dagNode-2"
+        id="dag__node--react-dom"
         onClick={[Function]}
       >
         <circle />
@@ -254,7 +252,8 @@ exports[`Storyshots dag/basic no wrapper 1`] = `
         />
       </g>
       <g
-        className="node Dag-dagNode-2"
+        className="dag__node Dag-dagNode-2"
+        id="dag__node--apollo"
         onClick={[Function]}
       >
         <circle />
@@ -263,7 +262,8 @@ exports[`Storyshots dag/basic no wrapper 1`] = `
         />
       </g>
       <g
-        className="node Dag-dagNode-2"
+        className="dag__node Dag-dagNode-2"
+        id="dag__node--enzyme"
         onClick={[Function]}
       >
         <circle />
@@ -310,70 +310,65 @@ exports[`Storyshots dag/themed paper wrapper (dark) 1`] = `
         width={500}
       >
         <g
-          className="graph"
+          className="dag__graph"
         >
           <g
-            className="connect-node Dag-dagEdge-79"
+            className="dag__edge Dag-dagEdge-79"
+            onClick={[Function]}
           >
-            <line
-              onClick={[Function]}
-            />
+            <line />
             <polygon
               className="dag__edge-arrow"
             />
           </g>
           <g
-            className="connect-node Dag-dagEdge-79"
+            className="dag__edge Dag-dagEdge-79"
+            onClick={[Function]}
           >
-            <line
-              onClick={[Function]}
-            />
+            <line />
             <polygon
               className="dag__edge-arrow"
             />
           </g>
           <g
-            className="connect-node Dag-dagEdge-79"
+            className="dag__edge Dag-dagEdge-79"
+            onClick={[Function]}
           >
-            <line
-              onClick={[Function]}
-            />
+            <line />
             <polygon
               className="dag__edge-arrow"
             />
           </g>
           <g
-            className="connect-node Dag-dagEdge-79"
+            className="dag__edge Dag-dagEdge-79"
+            onClick={[Function]}
           >
-            <line
-              onClick={[Function]}
-            />
+            <line />
             <polygon
               className="dag__edge-arrow"
             />
           </g>
           <g
-            className="connect-node Dag-dagEdge-79"
+            className="dag__edge Dag-dagEdge-79"
+            onClick={[Function]}
           >
-            <line
-              onClick={[Function]}
-            />
+            <line />
             <polygon
               className="dag__edge-arrow"
             />
           </g>
           <g
-            className="connect-node Dag-dagEdge-79"
+            className="dag__edge Dag-dagEdge-79"
+            onClick={[Function]}
           >
-            <line
-              onClick={[Function]}
-            />
+            <line />
             <polygon
               className="dag__edge-arrow"
             />
           </g>
           <g
-            className="node Dag-dagNode-77"
+            className="dag__node Dag-dagNode-77"
+            id="dag__node--app"
             onClick={[Function]}
           >
             <circle />
@@ -382,7 +377,8 @@ exports[`Storyshots dag/themed paper wrapper (dark) 1`] = `
             />
           </g>
           <g
-            className="node Dag-dagNode-77"
+            className="dag__node Dag-dagNode-77"
+            id="dag__node--lodash"
             onClick={[Function]}
           >
             <circle />
@@ -391,7 +387,8 @@ exports[`Storyshots dag/themed paper wrapper (dark) 1`] = `
             />
           </g>
           <g
-            className="node Dag-dagNode-77"
+            className="dag__node Dag-dagNode-77"
+            id="dag__node--react"
             onClick={[Function]}
           >
             <circle />
@@ -400,7 +397,8 @@ exports[`Storyshots dag/themed paper wrapper (dark) 1`] = `
             />
           </g>
           <g
-            className="node Dag-dagNode-77"
+            className="dag__node Dag-dagNode-77"
+            id="dag__node--react-dom"
             onClick={[Function]}
           >
             <circle />
@@ -409,7 +407,8 @@ exports[`Storyshots dag/themed paper wrapper (dark) 1`] = `
             />
           </g>
           <g
-            className="node Dag-dagNode-77"
+            className="dag__node Dag-dagNode-77"
+            id="dag__node--apollo"
             onClick={[Function]}
           >
             <circle />
@@ -418,7 +417,8 @@ exports[`Storyshots dag/themed paper wrapper (dark) 1`] = `
             />
           </g>
           <g
-            className="node Dag-dagNode-77"
+            className="dag__node Dag-dagNode-77"
+            id="dag__node--enzyme"
             onClick={[Function]}
           >
             <circle />
@@ -467,70 +467,65 @@ exports[`Storyshots dag/themed paper wrapper (light) 1`] = `
         width={500}
       >
         <g
-          className="graph"
+          className="dag__graph"
         >
           <g
-            className="connect-node Dag-dagEdge-45"
+            className="dag__edge Dag-dagEdge-45"
+            onClick={[Function]}
           >
-            <line
-              onClick={[Function]}
-            />
+            <line />
             <polygon
               className="dag__edge-arrow"
             />
           </g>
           <g
-            className="connect-node Dag-dagEdge-45"
+            className="dag__edge Dag-dagEdge-45"
+            onClick={[Function]}
           >
-            <line
-              onClick={[Function]}
-            />
+            <line />
             <polygon
               className="dag__edge-arrow"
             />
           </g>
           <g
-            className="connect-node Dag-dagEdge-45"
+            className="dag__edge Dag-dagEdge-45"
+            onClick={[Function]}
           >
-            <line
-              onClick={[Function]}
-            />
+            <line />
             <polygon
               className="dag__edge-arrow"
             />
           </g>
           <g
-            className="connect-node Dag-dagEdge-45"
+            className="dag__edge Dag-dagEdge-45"
+            onClick={[Function]}
           >
-            <line
-              onClick={[Function]}
-            />
+            <line />
             <polygon
               className="dag__edge-arrow"
             />
           </g>
           <g
-            className="connect-node Dag-dagEdge-45"
+            className="dag__edge Dag-dagEdge-45"
+            onClick={[Function]}
           >
-            <line
-              onClick={[Function]}
-            />
+            <line />
             <polygon
               className="dag__edge-arrow"
             />
           </g>
           <g
-            className="connect-node Dag-dagEdge-45"
+            className="dag__edge Dag-dagEdge-45"
+            onClick={[Function]}
           >
-            <line
-              onClick={[Function]}
-            />
+            <line />
             <polygon
               className="dag__edge-arrow"
             />
           </g>
           <g
-            className="node Dag-dagNode-43"
+            className="dag__node Dag-dagNode-43"
+            id="dag__node--app"
             onClick={[Function]}
           >
             <circle />
@@ -539,7 +534,8 @@ exports[`Storyshots dag/themed paper wrapper (light) 1`] = `
             />
           </g>
           <g
-            className="node Dag-dagNode-43"
+            className="dag__node Dag-dagNode-43"
+            id="dag__node--lodash"
             onClick={[Function]}
           >
             <circle />
@@ -548,7 +544,8 @@ exports[`Storyshots dag/themed paper wrapper (light) 1`] = `
             />
           </g>
           <g
-            className="node Dag-dagNode-43"
+            className="dag__node Dag-dagNode-43"
+            id="dag__node--react"
             onClick={[Function]}
           >
             <circle />
@@ -557,7 +554,8 @@ exports[`Storyshots dag/themed paper wrapper (light) 1`] = `
             />
           </g>
           <g
-            className="node Dag-dagNode-43"
+            className="dag__node Dag-dagNode-43"
+            id="dag__node--react-dom"
             onClick={[Function]}
           >
             <circle />
@@ -566,7 +564,8 @@ exports[`Storyshots dag/themed paper wrapper (light) 1`] = `
             />
           </g>
           <g
-            className="node Dag-dagNode-43"
+            className="dag__node Dag-dagNode-43"
+            id="dag__node--apollo"
             onClick={[Function]}
           >
             <circle />
@@ -575,7 +574,8 @@ exports[`Storyshots dag/themed paper wrapper (light) 1`] = `
             />
           </g>
           <g
-            className="node Dag-dagNode-43"
+            className="dag__node Dag-dagNode-43"
+            id="dag__node--enzyme"
             onClick={[Function]}
           >
             <circle />

--- a/packages/dag/test/__snapshots__/storyshot.test.js.snap
+++ b/packages/dag/test/__snapshots__/storyshot.test.js.snap
@@ -9,7 +9,7 @@ exports[`Storyshots dag/basic editable mode 1`] = `
   }
 >
   <svg
-    className="dag-wrapper Dag-root-7"
+    className="dag-wrapper Dag-root-8"
     height={500}
     onDoubleClick={[Function]}
     onMouseMove={[Function]}
@@ -19,82 +19,118 @@ exports[`Storyshots dag/basic editable mode 1`] = `
     <g
       className="graph"
     >
-      <line
-        className="connect-node Dag-dagEdge-10"
-        onClick={[Function]}
-      />
-      <line
-        className="connect-node Dag-dagEdge-10"
-        onClick={[Function]}
-      />
-      <line
-        className="connect-node Dag-dagEdge-10"
-        onClick={[Function]}
-      />
-      <line
-        className="connect-node Dag-dagEdge-10"
-        onClick={[Function]}
-      />
-      <line
-        className="connect-node Dag-dagEdge-10"
-        onClick={[Function]}
-      />
-      <line
-        className="connect-node Dag-dagEdge-10"
-        onClick={[Function]}
-      />
       <g
-        className="node Dag-dagNode-8"
-        onClick={[Function]}
+        className="connect-node Dag-dagEdge-11 Dag-dagEditable-12"
       >
-        <circle />
-        <text
-          className="Dag-dagNodeText-9"
+        <line
+          onClick={[Function]}
+        />
+        <polygon
+          className="dag__edge-arrow"
         />
       </g>
       <g
-        className="node Dag-dagNode-8"
-        onClick={[Function]}
+        className="connect-node Dag-dagEdge-11 Dag-dagEditable-12"
       >
-        <circle />
-        <text
-          className="Dag-dagNodeText-9"
+        <line
+          onClick={[Function]}
+        />
+        <polygon
+          className="dag__edge-arrow"
         />
       </g>
       <g
-        className="node Dag-dagNode-8"
-        onClick={[Function]}
+        className="connect-node Dag-dagEdge-11 Dag-dagEditable-12"
       >
-        <circle />
-        <text
-          className="Dag-dagNodeText-9"
+        <line
+          onClick={[Function]}
+        />
+        <polygon
+          className="dag__edge-arrow"
         />
       </g>
       <g
-        className="node Dag-dagNode-8"
-        onClick={[Function]}
+        className="connect-node Dag-dagEdge-11 Dag-dagEditable-12"
       >
-        <circle />
-        <text
-          className="Dag-dagNodeText-9"
+        <line
+          onClick={[Function]}
+        />
+        <polygon
+          className="dag__edge-arrow"
         />
       </g>
       <g
-        className="node Dag-dagNode-8"
-        onClick={[Function]}
+        className="connect-node Dag-dagEdge-11 Dag-dagEditable-12"
       >
-        <circle />
-        <text
-          className="Dag-dagNodeText-9"
+        <line
+          onClick={[Function]}
+        />
+        <polygon
+          className="dag__edge-arrow"
         />
       </g>
       <g
-        className="node Dag-dagNode-8"
+        className="connect-node Dag-dagEdge-11 Dag-dagEditable-12"
+      >
+        <line
+          onClick={[Function]}
+        />
+        <polygon
+          className="dag__edge-arrow"
+        />
+      </g>
+      <g
+        className="node Dag-dagNode-9 Dag-dagEditable-12"
         onClick={[Function]}
       >
         <circle />
         <text
-          className="Dag-dagNodeText-9"
+          className="Dag-dagNodeText-10"
+        />
+      </g>
+      <g
+        className="node Dag-dagNode-9 Dag-dagEditable-12"
+        onClick={[Function]}
+      >
+        <circle />
+        <text
+          className="Dag-dagNodeText-10"
+        />
+      </g>
+      <g
+        className="node Dag-dagNode-9 Dag-dagEditable-12"
+        onClick={[Function]}
+      >
+        <circle />
+        <text
+          className="Dag-dagNodeText-10"
+        />
+      </g>
+      <g
+        className="node Dag-dagNode-9 Dag-dagEditable-12"
+        onClick={[Function]}
+      >
+        <circle />
+        <text
+          className="Dag-dagNodeText-10"
+        />
+      </g>
+      <g
+        className="node Dag-dagNode-9 Dag-dagEditable-12"
+        onClick={[Function]}
+      >
+        <circle />
+        <text
+          className="Dag-dagNodeText-10"
+        />
+      </g>
+      <g
+        className="node Dag-dagNode-9 Dag-dagEditable-12"
+        onClick={[Function]}
+      >
+        <circle />
+        <text
+          className="Dag-dagNodeText-10"
         />
       </g>
     </g>
@@ -121,30 +157,66 @@ exports[`Storyshots dag/basic no wrapper 1`] = `
     <g
       className="graph"
     >
-      <line
+      <g
         className="connect-node Dag-dagEdge-4"
-        onClick={[Function]}
-      />
-      <line
+      >
+        <line
+          onClick={[Function]}
+        />
+        <polygon
+          className="dag__edge-arrow"
+        />
+      </g>
+      <g
         className="connect-node Dag-dagEdge-4"
-        onClick={[Function]}
-      />
-      <line
+      >
+        <line
+          onClick={[Function]}
+        />
+        <polygon
+          className="dag__edge-arrow"
+        />
+      </g>
+      <g
         className="connect-node Dag-dagEdge-4"
-        onClick={[Function]}
-      />
-      <line
+      >
+        <line
+          onClick={[Function]}
+        />
+        <polygon
+          className="dag__edge-arrow"
+        />
+      </g>
+      <g
         className="connect-node Dag-dagEdge-4"
-        onClick={[Function]}
-      />
-      <line
+      >
+        <line
+          onClick={[Function]}
+        />
+        <polygon
+          className="dag__edge-arrow"
+        />
+      </g>
+      <g
         className="connect-node Dag-dagEdge-4"
-        onClick={[Function]}
-      />
-      <line
+      >
+        <line
+          onClick={[Function]}
+        />
+        <polygon
+          className="dag__edge-arrow"
+        />
+      </g>
+      <g
         className="connect-node Dag-dagEdge-4"
-        onClick={[Function]}
-      />
+      >
+        <line
+          onClick={[Function]}
+        />
+        <polygon
+          className="dag__edge-arrow"
+        />
+      </g>
       <g
         className="node Dag-dagNode-2"
         onClick={[Function]}
@@ -214,7 +286,7 @@ exports[`Storyshots dag/themed paper wrapper (dark) 1`] = `
   }
 >
   <div
-    className="MuiPaper-root-46 MuiPaper-elevation2-50 MuiPaper-rounded-47"
+    className="MuiPaper-root-49 MuiPaper-elevation2-53 MuiPaper-rounded-50"
     style={
       Object {
         "height": "500px",
@@ -230,7 +302,7 @@ exports[`Storyshots dag/themed paper wrapper (dark) 1`] = `
       }
     >
       <svg
-        className="dag-wrapper Dag-root-73"
+        className="dag-wrapper Dag-root-76"
         height={500}
         onDoubleClick={[Function]}
         onMouseMove={[Function]}
@@ -240,82 +312,118 @@ exports[`Storyshots dag/themed paper wrapper (dark) 1`] = `
         <g
           className="graph"
         >
-          <line
-            className="connect-node Dag-dagEdge-76"
-            onClick={[Function]}
-          />
-          <line
-            className="connect-node Dag-dagEdge-76"
-            onClick={[Function]}
-          />
-          <line
-            className="connect-node Dag-dagEdge-76"
-            onClick={[Function]}
-          />
-          <line
-            className="connect-node Dag-dagEdge-76"
-            onClick={[Function]}
-          />
-          <line
-            className="connect-node Dag-dagEdge-76"
-            onClick={[Function]}
-          />
-          <line
-            className="connect-node Dag-dagEdge-76"
-            onClick={[Function]}
-          />
           <g
-            className="node Dag-dagNode-74"
-            onClick={[Function]}
+            className="connect-node Dag-dagEdge-79"
           >
-            <circle />
-            <text
-              className="Dag-dagNodeText-75"
+            <line
+              onClick={[Function]}
+            />
+            <polygon
+              className="dag__edge-arrow"
             />
           </g>
           <g
-            className="node Dag-dagNode-74"
-            onClick={[Function]}
+            className="connect-node Dag-dagEdge-79"
           >
-            <circle />
-            <text
-              className="Dag-dagNodeText-75"
+            <line
+              onClick={[Function]}
+            />
+            <polygon
+              className="dag__edge-arrow"
             />
           </g>
           <g
-            className="node Dag-dagNode-74"
-            onClick={[Function]}
+            className="connect-node Dag-dagEdge-79"
           >
-            <circle />
-            <text
-              className="Dag-dagNodeText-75"
+            <line
+              onClick={[Function]}
+            />
+            <polygon
+              className="dag__edge-arrow"
             />
           </g>
           <g
-            className="node Dag-dagNode-74"
-            onClick={[Function]}
+            className="connect-node Dag-dagEdge-79"
           >
-            <circle />
-            <text
-              className="Dag-dagNodeText-75"
+            <line
+              onClick={[Function]}
+            />
+            <polygon
+              className="dag__edge-arrow"
             />
           </g>
           <g
-            className="node Dag-dagNode-74"
-            onClick={[Function]}
+            className="connect-node Dag-dagEdge-79"
           >
-            <circle />
-            <text
-              className="Dag-dagNodeText-75"
+            <line
+              onClick={[Function]}
+            />
+            <polygon
+              className="dag__edge-arrow"
             />
           </g>
           <g
-            className="node Dag-dagNode-74"
+            className="connect-node Dag-dagEdge-79"
+          >
+            <line
+              onClick={[Function]}
+            />
+            <polygon
+              className="dag__edge-arrow"
+            />
+          </g>
+          <g
+            className="node Dag-dagNode-77"
             onClick={[Function]}
           >
             <circle />
             <text
-              className="Dag-dagNodeText-75"
+              className="Dag-dagNodeText-78"
+            />
+          </g>
+          <g
+            className="node Dag-dagNode-77"
+            onClick={[Function]}
+          >
+            <circle />
+            <text
+              className="Dag-dagNodeText-78"
+            />
+          </g>
+          <g
+            className="node Dag-dagNode-77"
+            onClick={[Function]}
+          >
+            <circle />
+            <text
+              className="Dag-dagNodeText-78"
+            />
+          </g>
+          <g
+            className="node Dag-dagNode-77"
+            onClick={[Function]}
+          >
+            <circle />
+            <text
+              className="Dag-dagNodeText-78"
+            />
+          </g>
+          <g
+            className="node Dag-dagNode-77"
+            onClick={[Function]}
+          >
+            <circle />
+            <text
+              className="Dag-dagNodeText-78"
+            />
+          </g>
+          <g
+            className="node Dag-dagNode-77"
+            onClick={[Function]}
+          >
+            <circle />
+            <text
+              className="Dag-dagNodeText-78"
             />
           </g>
         </g>
@@ -335,7 +443,7 @@ exports[`Storyshots dag/themed paper wrapper (light) 1`] = `
   }
 >
   <div
-    className="MuiPaper-root-13 MuiPaper-elevation2-17 MuiPaper-rounded-14"
+    className="MuiPaper-root-15 MuiPaper-elevation2-19 MuiPaper-rounded-16"
     style={
       Object {
         "height": "500px",
@@ -351,7 +459,7 @@ exports[`Storyshots dag/themed paper wrapper (light) 1`] = `
       }
     >
       <svg
-        className="dag-wrapper Dag-root-40"
+        className="dag-wrapper Dag-root-42"
         height={500}
         onDoubleClick={[Function]}
         onMouseMove={[Function]}
@@ -361,82 +469,118 @@ exports[`Storyshots dag/themed paper wrapper (light) 1`] = `
         <g
           className="graph"
         >
-          <line
-            className="connect-node Dag-dagEdge-43"
-            onClick={[Function]}
-          />
-          <line
-            className="connect-node Dag-dagEdge-43"
-            onClick={[Function]}
-          />
-          <line
-            className="connect-node Dag-dagEdge-43"
-            onClick={[Function]}
-          />
-          <line
-            className="connect-node Dag-dagEdge-43"
-            onClick={[Function]}
-          />
-          <line
-            className="connect-node Dag-dagEdge-43"
-            onClick={[Function]}
-          />
-          <line
-            className="connect-node Dag-dagEdge-43"
-            onClick={[Function]}
-          />
           <g
-            className="node Dag-dagNode-41"
-            onClick={[Function]}
+            className="connect-node Dag-dagEdge-45"
           >
-            <circle />
-            <text
-              className="Dag-dagNodeText-42"
+            <line
+              onClick={[Function]}
+            />
+            <polygon
+              className="dag__edge-arrow"
             />
           </g>
           <g
-            className="node Dag-dagNode-41"
-            onClick={[Function]}
+            className="connect-node Dag-dagEdge-45"
           >
-            <circle />
-            <text
-              className="Dag-dagNodeText-42"
+            <line
+              onClick={[Function]}
+            />
+            <polygon
+              className="dag__edge-arrow"
             />
           </g>
           <g
-            className="node Dag-dagNode-41"
-            onClick={[Function]}
+            className="connect-node Dag-dagEdge-45"
           >
-            <circle />
-            <text
-              className="Dag-dagNodeText-42"
+            <line
+              onClick={[Function]}
+            />
+            <polygon
+              className="dag__edge-arrow"
             />
           </g>
           <g
-            className="node Dag-dagNode-41"
-            onClick={[Function]}
+            className="connect-node Dag-dagEdge-45"
           >
-            <circle />
-            <text
-              className="Dag-dagNodeText-42"
+            <line
+              onClick={[Function]}
+            />
+            <polygon
+              className="dag__edge-arrow"
             />
           </g>
           <g
-            className="node Dag-dagNode-41"
-            onClick={[Function]}
+            className="connect-node Dag-dagEdge-45"
           >
-            <circle />
-            <text
-              className="Dag-dagNodeText-42"
+            <line
+              onClick={[Function]}
+            />
+            <polygon
+              className="dag__edge-arrow"
             />
           </g>
           <g
-            className="node Dag-dagNode-41"
+            className="connect-node Dag-dagEdge-45"
+          >
+            <line
+              onClick={[Function]}
+            />
+            <polygon
+              className="dag__edge-arrow"
+            />
+          </g>
+          <g
+            className="node Dag-dagNode-43"
             onClick={[Function]}
           >
             <circle />
             <text
-              className="Dag-dagNodeText-42"
+              className="Dag-dagNodeText-44"
+            />
+          </g>
+          <g
+            className="node Dag-dagNode-43"
+            onClick={[Function]}
+          >
+            <circle />
+            <text
+              className="Dag-dagNodeText-44"
+            />
+          </g>
+          <g
+            className="node Dag-dagNode-43"
+            onClick={[Function]}
+          >
+            <circle />
+            <text
+              className="Dag-dagNodeText-44"
+            />
+          </g>
+          <g
+            className="node Dag-dagNode-43"
+            onClick={[Function]}
+          >
+            <circle />
+            <text
+              className="Dag-dagNodeText-44"
+            />
+          </g>
+          <g
+            className="node Dag-dagNode-43"
+            onClick={[Function]}
+          >
+            <circle />
+            <text
+              className="Dag-dagNodeText-44"
+            />
+          </g>
+          <g
+            className="node Dag-dagNode-43"
+            onClick={[Function]}
+          >
+            <circle />
+            <text
+              className="Dag-dagNodeText-44"
             />
           </g>
         </g>

--- a/packages/dag/test/enzyme.test.js
+++ b/packages/dag/test/enzyme.test.js
@@ -20,11 +20,18 @@ describe('<Dag />', () => {
     expect(wrapper.find('.dag-wrapper').length).toBe(1);
     expect(onEdgeAdded).not.toHaveBeenCalled();
     wrapper
-      .find(`.${DAG_DEFAULTS.nodeClass}`)
+      .find(`.${DAG_DEFAULTS.nodeClass}`) // click on a node, open panel
       .at(0)
       .simulate('click');
     wrapper
-      .find(`.${DAG_DEFAULTS.nodeClass}`)
+      .find(`.${DAG_DEFAULTS.nodeClass}`) // click on a node, open panel
+      .at(0)
+      .find('button')
+      .at(1)
+      .find('SvgIcon')
+      .simulate('click');
+    wrapper
+      .find(`.${DAG_DEFAULTS.nodeClass}`) // click on another node
       .at(1)
       .simulate('click');
     expect(onEdgeAdded).toHaveBeenCalled();

--- a/packages/dag/test/enzyme.test.js
+++ b/packages/dag/test/enzyme.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { mount } from 'enzyme';
 
-import Dag from '../src';
+import Dag, { DAG_DEFAULTS } from '../src';
 
 describe('<Dag />', () => {
   it('renders one <Dag /> component', () => {
@@ -20,11 +20,11 @@ describe('<Dag />', () => {
     expect(wrapper.find('.dag-wrapper').length).toBe(1);
     expect(onEdgeAdded).not.toHaveBeenCalled();
     wrapper
-      .find('.node')
+      .find(`.${DAG_DEFAULTS.nodeClass}`)
       .at(0)
       .simulate('click');
     wrapper
-      .find('.node')
+      .find(`.${DAG_DEFAULTS.nodeClass}`)
       .at(1)
       .simulate('click');
     expect(onEdgeAdded).toHaveBeenCalled();


### PR DESCRIPTION
related to #97 

This PR is a WIP. Currently adds a new component inside dag namespace, called panel. It is used as a portal for other components to be rendered inside the graph (an SVG element). It is useful to show actions, like a remove action attached to a graph element, eg: an edge or node.

