### PR TITLE
dag: add custom idx fn

### DIFF
--- a/packages/dag/src/dag.js
+++ b/packages/dag/src/dag.js
@@ -40,7 +40,7 @@ const updateArrow = (arrow, line, nodeRadius) => {
 export default class DagCore {
   static DEFAULTS = DEFAULTS;
 
-  constructor(root, initialState) {
+  constructor(root, initialState, props = {}) {
     // root represents the svg element. It is required.
     this.state = {
       dragEnable: initialState.dragEnable || true,
@@ -50,6 +50,8 @@ export default class DagCore {
       width: initialState.width,
       nodes: initialState.nodes
     };
+
+    this.props = props;
 
     this.d3root = root;
     this.linesCache = [];
@@ -81,9 +83,7 @@ export default class DagCore {
       .force(
         'link',
         forceLink(edges)
-          .id(function(d) {
-            return d.title;
-          })
+          .id(this.props.getNodeIdx)
           .distance(nodeRadius)
           .strength(1)
       )

--- a/packages/dag/src/edge.js
+++ b/packages/dag/src/edge.js
@@ -44,7 +44,11 @@ export default class Edge extends Component {
   }
 
   handleEdgeClick = e => {
-    const { editable, data, editSelectedEdge, onEdgeClick, idx } = this.props;
+    const { editable, data, editSelectedEdge, onEdgeClick, idx, getNodeIdx, ghostEdge } = this.props;
+
+    if (ghostEdge) {
+      return;
+    }
 
     if (editable) {
       return editSelectedEdge({
@@ -54,8 +58,8 @@ export default class Edge extends Component {
     }
 
     onEdgeClick({
-      source: data.source.title,
-      target: data.target.title
+      source: getNodeIdx(data.source),
+      target: getNodeIdx(data.target)
     });
     // add selected state
     this.setState(prevState => ({

--- a/packages/dag/src/node.js
+++ b/packages/dag/src/node.js
@@ -74,15 +74,13 @@ export default class Node extends Component {
 
   handleNodeClick = e => {
     const { editable, editSelectedNode, onNodeClick, data, idx } = this.props;
-    const node = {
-      data,
-      x: data.x,
-      y: data.y,
-      idx: idx
-    };
 
     if (editable) {
-      return editSelectedNode(node);
+      return editSelectedNode({
+        x: data.x,
+        y: data.y,
+        idx: idx
+      });
     }
 
     onNodeClick(data);

--- a/packages/dag/src/node.js
+++ b/packages/dag/src/node.js
@@ -8,14 +8,14 @@ const enterNode = (selection, props) => {
     return props.nodeRadius;
   });
 
-  insertTitleLinebreaks(selection, props.name);
+  insertTitleLinebreaks(selection, props.data.title);
 };
 
 const updateNode = selection => {
   selection.attr('transform', d => `translate(${d.x}, ${d.y})`);
 };
 
-const insertTitleLinebreaks = (gEl, title) => {
+const insertTitleLinebreaks = (gEl, title = '') => {
   const words = title.split(/\s+/g);
   const nwords = words.length;
 
@@ -73,9 +73,9 @@ export default class Node extends Component {
   };
 
   handleNodeClick = e => {
-    const { editable, editSelectedNode, onNodeClick, data, idx, name } = this.props;
+    const { editable, editSelectedNode, onNodeClick, data, idx } = this.props;
     const node = {
-      title: name,
+      data,
       x: data.x,
       y: data.y,
       idx: idx
@@ -85,9 +85,13 @@ export default class Node extends Component {
       return editSelectedNode(node);
     }
 
-    onNodeClick({ title: name });
+    onNodeClick(data);
     // add selected state
     this.setState(prevState => ({ selected: !prevState.selected }));
+  };
+
+  handleDoubleClick = e => {
+    e.stopPropagation();
   };
 
   onTextChange = e => {
@@ -137,7 +141,6 @@ export default class Node extends Component {
       outerEl,
       classes,
       editable,
-      name,
       data,
       selectedClass,
       children,
@@ -161,8 +164,9 @@ export default class Node extends Component {
       <g
         className={classNames(DEFAULTS.nodeClass, nodeClasses)}
         onClick={this.handleNodeClick}
+        onDoubleClick={this.handleDoubleClick}
         ref={node => (this.node = node)}
-        id={`dag__node--${name}`}
+        id={`dag__node--${idx}`}
       >
         <circle />
         <text ref={node => (this.label = node)} className={classes.dagNodeText} />
@@ -180,7 +184,7 @@ export default class Node extends Component {
         {showPanel &&
           showPanelIdx === idx &&
           nodePanel &&
-          nodePanel({ outerEl, title: name, x: data.x, y: data.y, actions: this.getActions() })}
+          nodePanel({ outerEl, data, x: data.x, y: data.y, actions: this.getActions() })}
       </g>
     );
   }

--- a/packages/dag/src/panel.js
+++ b/packages/dag/src/panel.js
@@ -39,14 +39,14 @@ class GraphPanel extends Component {
     this.props.outerEl.removeChild(this.el);
   }
 
-  renderContentNode({ title }) {
+  renderContentNode({ node }) {
     return (
       <Grid item xs={12}>
         <Typography variant="caption" color="default">
           Node
         </Typography>
         <Typography variant="body2" color="inherit">
-          {title}
+          {node.title}
         </Typography>
       </Grid>
     );
@@ -76,14 +76,14 @@ class GraphPanel extends Component {
   }
 
   render() {
-    const { children, classes, title, source, target, style, actions = {} } = this.props;
+    const { children, classes, node, source, target, style, actions = {} } = this.props;
 
     return createPortal(
       <Card className={classes.panel} style={style}>
         <Grid item container alignItems="center">
           <Grid item xs={12} className={classes.details}>
             <CardContent className={classes.content}>
-              {title ? this.renderContentNode({ title }) : this.renderContentEdge({ source, target })}
+              {node ? this.renderContentNode({ node }) : this.renderContentEdge({ source, target })}
             </CardContent>
           </Grid>
           <Grid item xs={12}>

--- a/packages/dag/test/__snapshots__/storyshot.test.js.snap
+++ b/packages/dag/test/__snapshots__/storyshot.test.js.snap
@@ -83,6 +83,7 @@ exports[`Storyshots dag/basic editable mode 1`] = `
         className="dag__node Dag-dagNode-9 Dag-dagEditable-12"
         id="dag__node--app"
         onClick={[Function]}
+        onDoubleClick={[Function]}
       >
         <circle />
         <text
@@ -93,6 +94,7 @@ exports[`Storyshots dag/basic editable mode 1`] = `
         className="dag__node Dag-dagNode-9 Dag-dagEditable-12"
         id="dag__node--lodash"
         onClick={[Function]}
+        onDoubleClick={[Function]}
       >
         <circle />
         <text
@@ -103,6 +105,7 @@ exports[`Storyshots dag/basic editable mode 1`] = `
         className="dag__node Dag-dagNode-9 Dag-dagEditable-12"
         id="dag__node--react"
         onClick={[Function]}
+        onDoubleClick={[Function]}
       >
         <circle />
         <text
@@ -113,6 +116,7 @@ exports[`Storyshots dag/basic editable mode 1`] = `
         className="dag__node Dag-dagNode-9 Dag-dagEditable-12"
         id="dag__node--react-dom"
         onClick={[Function]}
+        onDoubleClick={[Function]}
       >
         <circle />
         <text
@@ -123,6 +127,7 @@ exports[`Storyshots dag/basic editable mode 1`] = `
         className="dag__node Dag-dagNode-9 Dag-dagEditable-12"
         id="dag__node--apollo"
         onClick={[Function]}
+        onDoubleClick={[Function]}
       >
         <circle />
         <text
@@ -133,6 +138,7 @@ exports[`Storyshots dag/basic editable mode 1`] = `
         className="dag__node Dag-dagNode-9 Dag-dagEditable-12"
         id="dag__node--enzyme"
         onClick={[Function]}
+        onDoubleClick={[Function]}
       >
         <circle />
         <text
@@ -227,6 +233,7 @@ exports[`Storyshots dag/basic no wrapper 1`] = `
         className="dag__node Dag-dagNode-2"
         id="dag__node--app"
         onClick={[Function]}
+        onDoubleClick={[Function]}
       >
         <circle />
         <text
@@ -237,6 +244,7 @@ exports[`Storyshots dag/basic no wrapper 1`] = `
         className="dag__node Dag-dagNode-2"
         id="dag__node--lodash"
         onClick={[Function]}
+        onDoubleClick={[Function]}
       >
         <circle />
         <text
@@ -247,6 +255,7 @@ exports[`Storyshots dag/basic no wrapper 1`] = `
         className="dag__node Dag-dagNode-2"
         id="dag__node--react"
         onClick={[Function]}
+        onDoubleClick={[Function]}
       >
         <circle />
         <text
@@ -257,6 +266,7 @@ exports[`Storyshots dag/basic no wrapper 1`] = `
         className="dag__node Dag-dagNode-2"
         id="dag__node--react-dom"
         onClick={[Function]}
+        onDoubleClick={[Function]}
       >
         <circle />
         <text
@@ -267,6 +277,7 @@ exports[`Storyshots dag/basic no wrapper 1`] = `
         className="dag__node Dag-dagNode-2"
         id="dag__node--apollo"
         onClick={[Function]}
+        onDoubleClick={[Function]}
       >
         <circle />
         <text
@@ -277,6 +288,7 @@ exports[`Storyshots dag/basic no wrapper 1`] = `
         className="dag__node Dag-dagNode-2"
         id="dag__node--enzyme"
         onClick={[Function]}
+        onDoubleClick={[Function]}
       >
         <circle />
         <text
@@ -388,6 +400,7 @@ exports[`Storyshots dag/themed paper wrapper (dark) 1`] = `
             className="dag__node Dag-dagNode-77"
             id="dag__node--app"
             onClick={[Function]}
+            onDoubleClick={[Function]}
           >
             <circle />
             <text
@@ -398,6 +411,7 @@ exports[`Storyshots dag/themed paper wrapper (dark) 1`] = `
             className="dag__node Dag-dagNode-77"
             id="dag__node--lodash"
             onClick={[Function]}
+            onDoubleClick={[Function]}
           >
             <circle />
             <text
@@ -408,6 +422,7 @@ exports[`Storyshots dag/themed paper wrapper (dark) 1`] = `
             className="dag__node Dag-dagNode-77"
             id="dag__node--react"
             onClick={[Function]}
+            onDoubleClick={[Function]}
           >
             <circle />
             <text
@@ -418,6 +433,7 @@ exports[`Storyshots dag/themed paper wrapper (dark) 1`] = `
             className="dag__node Dag-dagNode-77"
             id="dag__node--react-dom"
             onClick={[Function]}
+            onDoubleClick={[Function]}
           >
             <circle />
             <text
@@ -428,6 +444,7 @@ exports[`Storyshots dag/themed paper wrapper (dark) 1`] = `
             className="dag__node Dag-dagNode-77"
             id="dag__node--apollo"
             onClick={[Function]}
+            onDoubleClick={[Function]}
           >
             <circle />
             <text
@@ -438,6 +455,7 @@ exports[`Storyshots dag/themed paper wrapper (dark) 1`] = `
             className="dag__node Dag-dagNode-77"
             id="dag__node--enzyme"
             onClick={[Function]}
+            onDoubleClick={[Function]}
           >
             <circle />
             <text
@@ -551,6 +569,7 @@ exports[`Storyshots dag/themed paper wrapper (light) 1`] = `
             className="dag__node Dag-dagNode-43"
             id="dag__node--app"
             onClick={[Function]}
+            onDoubleClick={[Function]}
           >
             <circle />
             <text
@@ -561,6 +580,7 @@ exports[`Storyshots dag/themed paper wrapper (light) 1`] = `
             className="dag__node Dag-dagNode-43"
             id="dag__node--lodash"
             onClick={[Function]}
+            onDoubleClick={[Function]}
           >
             <circle />
             <text
@@ -571,6 +591,7 @@ exports[`Storyshots dag/themed paper wrapper (light) 1`] = `
             className="dag__node Dag-dagNode-43"
             id="dag__node--react"
             onClick={[Function]}
+            onDoubleClick={[Function]}
           >
             <circle />
             <text
@@ -581,6 +602,7 @@ exports[`Storyshots dag/themed paper wrapper (light) 1`] = `
             className="dag__node Dag-dagNode-43"
             id="dag__node--react-dom"
             onClick={[Function]}
+            onDoubleClick={[Function]}
           >
             <circle />
             <text
@@ -591,6 +613,7 @@ exports[`Storyshots dag/themed paper wrapper (light) 1`] = `
             className="dag__node Dag-dagNode-43"
             id="dag__node--apollo"
             onClick={[Function]}
+            onDoubleClick={[Function]}
           >
             <circle />
             <text
@@ -601,6 +624,7 @@ exports[`Storyshots dag/themed paper wrapper (light) 1`] = `
             className="dag__node Dag-dagNode-43"
             id="dag__node--enzyme"
             onClick={[Function]}
+            onDoubleClick={[Function]}
           >
             <circle />
             <text


### PR DESCRIPTION
By default, the dag uses an idx based on the `title` prop of each node but now you can change that using a custom function `getNodeIdx`