### PR TITLE
loader: update default component prop to 'circular'

### DIFF
--- a/examples/enterprise-demo/src/containers/App.js
+++ b/examples/enterprise-demo/src/containers/App.js
@@ -45,7 +45,7 @@ class App extends Component {
       <BrowserRouter>
         <MuiThemeProvider theme={this.createTheme()}>
           <CssBaseline>
-            <Loader loading={!currentUser && loadingUser}>
+            <Loader loading={!currentUser && loadingUser} component="linear" fullscreen>
               <Switch>
                 <Route
                   path={SIGN_IN}

--- a/packages/widgets/.storybook/addons.js
+++ b/packages/widgets/.storybook/addons.js
@@ -1,0 +1,1 @@
+import '@storybook/addon-knobs/register';

--- a/packages/widgets/README.md
+++ b/packages/widgets/README.md
@@ -7,7 +7,7 @@ Set of small Lattice components for common tasks like loaders, side-menus and mo
 - [Install](#install)
 - [Loader](#loader)
 - [SideMenu](#sidemenu)
-- [Widget](#widget) 
+- [Widget](#widget)
 
 ## <a name="install"></a>Install
 
@@ -25,15 +25,15 @@ import { Loader } from '@latticejs/widgets';
 
 class App extends Component {
   state = {
-    isLoading: true 
+    isLoading: true
   };
 
   componentDidMount() {
     setTimeout(() => {
       this.setState({
-        isLoading: false 
+        isLoading: false
       });
-    }, 2000);    
+    }, 2000);
   }
 
   render() {
@@ -42,7 +42,7 @@ class App extends Component {
       <Loader loading={isLoading}>
         <h1>Loaded!</h1>
       </Loader>
-    );    
+    );
   }
 }
 ```
@@ -57,7 +57,7 @@ Used to indicate when the content is loaded and the loader should disappear.
 
 #### component
 
-> `string`/`function` | defaults to `linear`
+> `string`/`function` | defaults to `circular`
 
 Used to indicate the type of loader. `Loader` comes with a couple of predefined loaders, these are: `linear` and `circular`. It can also receive a custom function (stateless component) as a loader.
 
@@ -66,6 +66,12 @@ Used to indicate the type of loader. `Loader` comes with a couple of predefined 
 > `function` | defaults to `undefined`
 
 Used to indicate the content to be displayed after the loader.
+
+#### fullscreen
+
+> `boolean` | defaults to `false`
+
+Used to indicate if the loader needs to be resizer to the entire screen (100vh x 100vw)
 
 ## <a name="sidemenu"></a>SideMenu
 
@@ -93,9 +99,9 @@ const navigation = [
 class App extends Component {
   render() {
     return (
-      <SideMenu 
+      <SideMenu
         navigation={navigation}
-        onItemClick={(item) => console.log(item)} 
+        onItemClick={(item) => console.log(item)}
       />
     )
   }
@@ -114,7 +120,7 @@ Used to indicate navigable routes.
 
 > `object` | defaults to `undefined`
 
-Used to indicate if a route should be highlighted or selected. 
+Used to indicate if a route should be highlighted or selected.
 
 #### onItemClick
 
@@ -134,7 +140,7 @@ Used to indicate component's width.
 
 Used to indicate component's min width.
 
-## <a name="widget"></a>Widget 
+## <a name="widget"></a>Widget
 
 ### Usage
 
@@ -146,9 +152,9 @@ class App extends Component {
   render() {
     return (
       <Widget featured title="Title">
-        Basic Widget 
+        Basic Widget
       </Widget>
-    )    
+    )
   }
 }
 ```

--- a/packages/widgets/package.json
+++ b/packages/widgets/package.json
@@ -26,6 +26,7 @@
   "devDependencies": {
     "@material-ui/core": "^1.0.0",
     "@material-ui/icons": "^2.0.0",
+    "@storybook/addon-knobs": "^3.4.8",
     "@storybook/addon-storyshots": "^3.4.5",
     "@storybook/react": "^3.4.5",
     "@taskr/babel": "^1.1.0",
@@ -60,7 +61,8 @@
     "taskr-rollup": "^0.0.4"
   },
   "dependencies": {
-    "classnames": "^2.2.5"
+    "classnames": "^2.2.5",
+    "prop-types": "^15.6.2"
   },
   "jest": {
     "setupFiles": [

--- a/packages/widgets/src/Loader.js
+++ b/packages/widgets/src/Loader.js
@@ -1,4 +1,6 @@
 import React from 'react';
+import PropTypes from 'prop-types';
+import classnames from 'classnames';
 
 // Material-UI
 import { withStyles } from '@material-ui/core/styles';
@@ -8,15 +10,18 @@ import LinearProgress from '@material-ui/core/LinearProgress';
 
 const styles = theme => ({
   root: {
-    height: '100vh',
+    height: '100%',
     flexGrow: 1
+  },
+  fullscreen: {
+    height: '100vh'
   },
   linear: {
     width: '100%'
   }
 });
 
-function Loader({ classes, loading, component = 'linear', children }) {
+function Loader({ classes, loading, component, fullscreen, className, children }) {
   let render;
   if (component === 'linear') {
     render = <LinearProgress className={classes.linear} />;
@@ -26,15 +31,37 @@ function Loader({ classes, loading, component = 'linear', children }) {
     render = component();
   }
 
+  const _className = classnames(className, classes.root, {
+    [classes.fullscreen]: fullscreen
+  });
+
   if (loading) {
     return (
-      <Grid container className={classes.root} alignItems="center" justify="center">
+      <Grid container className={_className} alignItems="center" justify="center">
         {render}
       </Grid>
     );
   }
 
-  return children;
+  if (children) {
+    return children;
+  }
+
+  return null;
 }
+
+Loader.propTypes = {
+  component: PropTypes.oneOfType([PropTypes.oneOf(['circular', 'linear']), PropTypes.func]),
+  loading: PropTypes.bool,
+  classes: PropTypes.object,
+  fullscreen: PropTypes.bool,
+  children: PropTypes.element,
+  className: PropTypes.string
+};
+
+Loader.defaultProps = {
+  component: 'circular',
+  fullscreen: false
+};
 
 export default withStyles(styles)(Loader);

--- a/packages/widgets/src/Loader.js
+++ b/packages/widgets/src/Loader.js
@@ -14,14 +14,15 @@ const styles = theme => ({
     flexGrow: 1
   },
   fullscreen: {
-    height: '100vh'
+    height: '100vh',
+    width: '100vw'
   },
   linear: {
     width: '100%'
   }
 });
 
-function Loader({ classes, loading, component, fullscreen, className, children }) {
+function InnerLoader({ classes, loading, component, fullscreen, className, children }) {
   let render;
   if (component === 'linear') {
     render = <LinearProgress className={classes.linear} />;
@@ -50,18 +51,20 @@ function Loader({ classes, loading, component, fullscreen, className, children }
   return null;
 }
 
+const LoaderStyled = withStyles(styles)(InnerLoader);
+
+const Loader = props => <LoaderStyled {...props} />;
+
+export default Loader;
+
 Loader.propTypes = {
   component: PropTypes.oneOfType([PropTypes.oneOf(['circular', 'linear']), PropTypes.func]),
   loading: PropTypes.bool,
-  classes: PropTypes.object,
   fullscreen: PropTypes.bool,
-  children: PropTypes.element,
-  className: PropTypes.string
+  children: PropTypes.element
 };
 
 Loader.defaultProps = {
   component: 'circular',
   fullscreen: false
 };
-
-export default withStyles(styles)(Loader);

--- a/packages/widgets/src/Loader.js
+++ b/packages/widgets/src/Loader.js
@@ -15,7 +15,8 @@ const styles = theme => ({
   },
   fullscreen: {
     height: '100vh',
-    width: '100vw'
+    width: '100%',
+    position: 'absolute'
   },
   linear: {
     width: '100%'

--- a/packages/widgets/src/Loader.js
+++ b/packages/widgets/src/Loader.js
@@ -22,7 +22,7 @@ const styles = theme => ({
   }
 });
 
-function InnerLoader({ classes, loading, component, fullscreen, className, children }) {
+function Loader({ classes, loading, component, fullscreen, className, children }) {
   let render;
   if (component === 'linear') {
     render = <LinearProgress className={classes.linear} />;
@@ -51,11 +51,7 @@ function InnerLoader({ classes, loading, component, fullscreen, className, child
   return null;
 }
 
-const LoaderStyled = withStyles(styles)(InnerLoader);
-
-const Loader = props => <LoaderStyled {...props} />;
-
-export default Loader;
+export default withStyles(styles)(Loader);
 
 Loader.propTypes = {
   component: PropTypes.oneOfType([PropTypes.oneOf(['circular', 'linear']), PropTypes.func]),

--- a/packages/widgets/stories/loader.js
+++ b/packages/widgets/stories/loader.js
@@ -1,4 +1,5 @@
-import React, { Component } from 'react';
+import React from 'react';
+import { withKnobs, boolean } from '@storybook/addon-knobs';
 
 // Material UI
 import Grid from '@material-ui/core/Grid';
@@ -23,26 +24,6 @@ const InGrid = story => (
   </Grid>
 );
 
-class LazyData extends Component {
-  constructor(props) {
-    super(props);
-
-    this.state = {
-      loading: true
-    };
-  }
-
-  componentDidMount() {
-    setTimeout(() => {
-      this.setState({ loading: false });
-    }, 3000);
-  }
-
-  render() {
-    return this.props.children({ loading: this.state.loading });
-  }
-}
-
 const Loaded = () => (
   <Grid container alignItems="center" justify="center" style={{ height: '100vh' }}>
     <Grid item xs={2}>
@@ -57,36 +38,30 @@ const Loaded = () => (
   </Grid>
 );
 
+const dynamicProps = () => ({
+  loading: boolean('LOADING', true),
+  fullscreen: boolean('FULLSCREEN', false)
+});
+
 export default ({ storiesOf, action }) => {
   storiesOf('widgets/Loader', module)
+    .addDecorator(withKnobs)
     .addDecorator(JssDecorator)
     .addDecorator(InGrid)
     .addDecorator(muiTheme())
-    .add('linear', () => (
-      <LazyData>
-        {({ loading }) => (
-          <Loader loading={loading}>
-            <Loaded />
-          </Loader>
-        )}
-      </LazyData>
-    ))
     .add('circular', () => (
-      <LazyData>
-        {({ loading }) => (
-          <Loader loading={loading} component="circular">
-            <Loaded />
-          </Loader>
-        )}
-      </LazyData>
+      <Loader {...dynamicProps()}>
+        <Loaded />
+      </Loader>
+    ))
+    .add('linear', () => (
+      <Loader {...dynamicProps()} component="linear">
+        <Loaded />
+      </Loader>
     ))
     .add('custom', () => (
-      <LazyData>
-        {({ loading }) => (
-          <Loader loading={loading} component={() => <CircularProgress style={{ color: purple[500] }} thickness={7} />}>
-            <Loaded />
-          </Loader>
-        )}
-      </LazyData>
+      <Loader {...dynamicProps()} component={() => <CircularProgress style={{ color: purple[500] }} thickness={7} />}>
+        <Loaded />
+      </Loader>
     ));
 };

--- a/packages/widgets/test/__snapshots__/storyshot.test.js.snap
+++ b/packages/widgets/test/__snapshots__/storyshot.test.js.snap
@@ -8,7 +8,7 @@ exports[`Storyshots widgets/Loader circular 1`] = `
     className="MuiGrid-item-2 MuiGrid-grid-xs-12-41"
   >
     <div
-      className="MuiGrid-container-1 MuiGrid-align-items-xs-center-9 MuiGrid-justify-xs-center-18 InnerLoader-root-1"
+      className="MuiGrid-container-1 MuiGrid-align-items-xs-center-9 MuiGrid-justify-xs-center-18 Loader-root-1"
     >
       <div
         className="MuiCircularProgress-root MuiCircularProgress-colorPrimary MuiCircularProgress-indeterminate"
@@ -48,7 +48,7 @@ exports[`Storyshots widgets/Loader custom 1`] = `
     className="MuiGrid-item-196 MuiGrid-grid-xs-12-235"
   >
     <div
-      className="MuiGrid-container-195 MuiGrid-align-items-xs-center-203 MuiGrid-justify-xs-center-212 InnerLoader-root-1"
+      className="MuiGrid-container-195 MuiGrid-align-items-xs-center-203 MuiGrid-justify-xs-center-212 Loader-root-1"
     >
       <div
         className="MuiCircularProgress-root MuiCircularProgress-colorPrimary MuiCircularProgress-indeterminate"
@@ -89,10 +89,10 @@ exports[`Storyshots widgets/Loader linear 1`] = `
     className="MuiGrid-item-99 MuiGrid-grid-xs-12-138"
   >
     <div
-      className="MuiGrid-container-98 MuiGrid-align-items-xs-center-106 MuiGrid-justify-xs-center-115 InnerLoader-root-1"
+      className="MuiGrid-container-98 MuiGrid-align-items-xs-center-106 MuiGrid-justify-xs-center-115 Loader-root-1"
     >
       <div
-        className="MuiLinearProgress-root MuiLinearProgress-colorPrimary InnerLoader-linear-3"
+        className="MuiLinearProgress-root MuiLinearProgress-colorPrimary Loader-linear-3"
         role="progressbar"
       >
         <div

--- a/packages/widgets/test/__snapshots__/storyshot.test.js.snap
+++ b/packages/widgets/test/__snapshots__/storyshot.test.js.snap
@@ -2,13 +2,13 @@
 
 exports[`Storyshots widgets/Loader circular 1`] = `
 <div
-  className="MuiGrid-container-98"
+  className="MuiGrid-container-1"
 >
   <div
-    className="MuiGrid-item-99 MuiGrid-grid-xs-12-138"
+    className="MuiGrid-item-2 MuiGrid-grid-xs-12-41"
   >
     <div
-      className="MuiGrid-container-98 MuiGrid-align-items-xs-center-106 MuiGrid-justify-xs-center-115 Loader-root-1"
+      className="MuiGrid-container-1 MuiGrid-align-items-xs-center-9 MuiGrid-justify-xs-center-18 Loader-root-1"
     >
       <div
         className="MuiCircularProgress-root MuiCircularProgress-colorPrimary MuiCircularProgress-indeterminate"
@@ -83,16 +83,16 @@ exports[`Storyshots widgets/Loader custom 1`] = `
 
 exports[`Storyshots widgets/Loader linear 1`] = `
 <div
-  className="MuiGrid-container-1"
+  className="MuiGrid-container-98"
 >
   <div
-    className="MuiGrid-item-2 MuiGrid-grid-xs-12-41"
+    className="MuiGrid-item-99 MuiGrid-grid-xs-12-138"
   >
     <div
-      className="MuiGrid-container-1 MuiGrid-align-items-xs-center-9 MuiGrid-justify-xs-center-18 Loader-root-1"
+      className="MuiGrid-container-98 MuiGrid-align-items-xs-center-106 MuiGrid-justify-xs-center-115 Loader-root-1"
     >
       <div
-        className="MuiLinearProgress-root MuiLinearProgress-colorPrimary Loader-linear-2"
+        className="MuiLinearProgress-root MuiLinearProgress-colorPrimary Loader-linear-3"
         role="progressbar"
       >
         <div

--- a/packages/widgets/test/__snapshots__/storyshot.test.js.snap
+++ b/packages/widgets/test/__snapshots__/storyshot.test.js.snap
@@ -8,7 +8,7 @@ exports[`Storyshots widgets/Loader circular 1`] = `
     className="MuiGrid-item-2 MuiGrid-grid-xs-12-41"
   >
     <div
-      className="MuiGrid-container-1 MuiGrid-align-items-xs-center-9 MuiGrid-justify-xs-center-18 Loader-root-1"
+      className="MuiGrid-container-1 MuiGrid-align-items-xs-center-9 MuiGrid-justify-xs-center-18 InnerLoader-root-1"
     >
       <div
         className="MuiCircularProgress-root MuiCircularProgress-colorPrimary MuiCircularProgress-indeterminate"
@@ -48,7 +48,7 @@ exports[`Storyshots widgets/Loader custom 1`] = `
     className="MuiGrid-item-196 MuiGrid-grid-xs-12-235"
   >
     <div
-      className="MuiGrid-container-195 MuiGrid-align-items-xs-center-203 MuiGrid-justify-xs-center-212 Loader-root-1"
+      className="MuiGrid-container-195 MuiGrid-align-items-xs-center-203 MuiGrid-justify-xs-center-212 InnerLoader-root-1"
     >
       <div
         className="MuiCircularProgress-root MuiCircularProgress-colorPrimary MuiCircularProgress-indeterminate"
@@ -89,10 +89,10 @@ exports[`Storyshots widgets/Loader linear 1`] = `
     className="MuiGrid-item-99 MuiGrid-grid-xs-12-138"
   >
     <div
-      className="MuiGrid-container-98 MuiGrid-align-items-xs-center-106 MuiGrid-justify-xs-center-115 Loader-root-1"
+      className="MuiGrid-container-98 MuiGrid-align-items-xs-center-106 MuiGrid-justify-xs-center-115 InnerLoader-root-1"
     >
       <div
-        className="MuiLinearProgress-root MuiLinearProgress-colorPrimary Loader-linear-3"
+        className="MuiLinearProgress-root MuiLinearProgress-colorPrimary InnerLoader-linear-3"
         role="progressbar"
       >
         <div

--- a/yarn.lock
+++ b/yarn.lock
@@ -731,6 +731,23 @@
     react-inspector "^2.2.2"
     uuid "^3.2.1"
 
+"@storybook/addon-knobs@^3.4.8":
+  version "3.4.8"
+  resolved "https://registry.yarnpkg.com/@storybook/addon-knobs/-/addon-knobs-3.4.8.tgz#d185cd689ea4509dd9d19601e62f8457361991b3"
+  dependencies:
+    "@storybook/components" "3.4.8"
+    babel-runtime "^6.26.0"
+    deep-equal "^1.0.1"
+    global "^4.3.2"
+    insert-css "^2.0.0"
+    lodash.debounce "^4.0.8"
+    moment "^2.21.0"
+    prop-types "^15.6.1"
+    react-color "^2.14.0"
+    react-datetime "^2.14.0"
+    react-textarea-autosize "^5.2.1"
+    util-deprecate "^1.0.2"
+
 "@storybook/addon-links@3.4.8":
   version "3.4.8"
   resolved "https://registry.yarnpkg.com/@storybook/addon-links/-/addon-links-3.4.8.tgz#303e2e37c8abf1861accc95dd9c5f9274bf528ad"
@@ -4009,7 +4026,7 @@ create-hmac@^1.1.0, create-hmac@^1.1.2, create-hmac@^1.1.4:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
-create-react-class@^15.6.2:
+create-react-class@^15.5.2, create-react-class@^15.6.2:
   version "15.6.3"
   resolved "https://registry.yarnpkg.com/create-react-class/-/create-react-class-15.6.3.tgz#2d73237fb3f970ae6ebe011a9e66f46dbca80036"
   dependencies:
@@ -6948,6 +6965,10 @@ inquirer@^5.2.0:
     strip-ansi "^4.0.0"
     through "^2.3.6"
 
+insert-css@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/insert-css/-/insert-css-2.0.0.tgz#eb5d1097b7542f4c79ea3060d3aee07d053880f4"
+
 internal-ip@1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/internal-ip/-/internal-ip-1.2.0.tgz#ae9fbf93b984878785d50a8de1b356956058cf5c"
@@ -8575,7 +8596,7 @@ lodash.uniq@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
 
-lodash@4, "lodash@>=3.5 <5", lodash@^4.13.1, lodash@^4.15.0, lodash@^4.17.0, lodash@^4.17.10, lodash@^4.17.2, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.3.0, lodash@^4.5.1, lodash@~4.17.4:
+lodash@4, "lodash@>=3.5 <5", lodash@^4.0.1, lodash@^4.13.1, lodash@^4.15.0, lodash@^4.17.0, lodash@^4.17.10, lodash@^4.17.2, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.3.0, lodash@^4.5.1, lodash@~4.17.4:
   version "4.17.10"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
 
@@ -8700,6 +8721,10 @@ markdown-loader@^2.0.1, markdown-loader@^2.0.2:
 marked@^0.3.9:
   version "0.3.19"
   resolved "https://registry.yarnpkg.com/marked/-/marked-0.3.19.tgz#5d47f709c4c9fc3c216b6d46127280f40b39d790"
+
+material-colors@^1.2.1:
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/material-colors/-/material-colors-1.2.6.tgz#6d1958871126992ceecc72f4bcc4d8f010865f46"
 
 math-expression-evaluator@^1.2.14:
   version "1.2.17"
@@ -8963,7 +8988,7 @@ modify-values@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/modify-values/-/modify-values-1.0.1.tgz#b3939fa605546474e3e3e3c63d64bd43b4ee6022"
 
-moment@^2.6.0:
+moment@^2.21.0, moment@^2.6.0:
   version "2.22.2"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.22.2.tgz#3c257f9839fc0e93ff53149632239eb90783ff66"
 
@@ -9287,6 +9312,10 @@ oauth-sign@~0.8.2:
 object-assign@4.1.1, object-assign@^4, object-assign@^4.0.1, object-assign@^4.1.0, object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
+
+object-assign@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-3.0.0.tgz#9bedd5ca0897949bca47e7ff408062d549f587f2"
 
 object-copy@^0.1.0:
   version "0.1.0"
@@ -10276,7 +10305,7 @@ prompts@^0.1.9:
     kleur "^2.0.1"
     sisteransi "^0.1.1"
 
-prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.8, prop-types@^15.5.9, prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2:
+prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.7, prop-types@^15.5.8, prop-types@^15.5.9, prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2:
   version "15.6.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.2.tgz#05d5ca77b4453e985d60fc7ff8c859094a497102"
   dependencies:
@@ -10495,6 +10524,16 @@ react-apollo@^2.1.9:
     lodash "^4.17.10"
     prop-types "^15.6.0"
 
+react-color@^2.14.0:
+  version "2.14.1"
+  resolved "https://registry.yarnpkg.com/react-color/-/react-color-2.14.1.tgz#db8ad4f45d81e74896fc2e1c99508927c6d084e0"
+  dependencies:
+    lodash "^4.0.1"
+    material-colors "^1.2.1"
+    prop-types "^15.5.10"
+    reactcss "^1.2.0"
+    tinycolor2 "^1.4.1"
+
 react-custom-scrollbars@^4.2.1:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/react-custom-scrollbars/-/react-custom-scrollbars-4.2.1.tgz#830fd9502927e97e8a78c2086813899b2a8b66db"
@@ -10502,6 +10541,15 @@ react-custom-scrollbars@^4.2.1:
     dom-css "^2.0.0"
     prop-types "^15.5.10"
     raf "^3.1.0"
+
+react-datetime@^2.14.0:
+  version "2.15.0"
+  resolved "https://registry.yarnpkg.com/react-datetime/-/react-datetime-2.15.0.tgz#a8f7da6c58b6b45dbeea32d4e8485db17614e12c"
+  dependencies:
+    create-react-class "^15.5.2"
+    object-assign "^3.0.0"
+    prop-types "^15.5.7"
+    react-onclickoutside "^6.5.0"
 
 react-dev-utils@^5.0.0, react-dev-utils@^5.0.1:
   version "5.0.1"
@@ -10622,6 +10670,10 @@ react-modal@^3.3.2:
     react-lifecycles-compat "^3.0.0"
     warning "^3.0.0"
 
+react-onclickoutside@^6.5.0:
+  version "6.7.1"
+  resolved "https://registry.yarnpkg.com/react-onclickoutside/-/react-onclickoutside-6.7.1.tgz#6a5b5b8b4eae6b776259712c89c8a2b36b17be93"
+
 react-reconciler@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/react-reconciler/-/react-reconciler-0.7.0.tgz#9614894103e5f138deeeb5eabaf3ee80eb1d026d"
@@ -10738,6 +10790,12 @@ react-test-renderer@^16.0.0-0, react-test-renderer@^16.3.2, react-test-renderer@
     prop-types "^15.6.0"
     react-is "^16.4.1"
 
+react-textarea-autosize@^5.2.1:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/react-textarea-autosize/-/react-textarea-autosize-5.2.1.tgz#2b78f9067180f41b08ac59f78f1581abadd61e54"
+  dependencies:
+    prop-types "^15.6.0"
+
 react-transition-group@^2.0.0, react-transition-group@^2.2.1:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-2.4.0.tgz#1d9391fabfd82e016f26fabd1eec329dbd922b5a"
@@ -10777,6 +10835,12 @@ react@^16.0.0, react@^16.2.0, react@^16.4.0, react@^16.4.1:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
     prop-types "^15.6.0"
+
+reactcss@^1.2.0:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/reactcss/-/reactcss-1.2.3.tgz#c00013875e557b1cf0dfd9a368a1c3dab3b548dd"
+  dependencies:
+    lodash "^4.0.1"
 
 read-cmd-shim@^1.0.1:
   version "1.0.1"
@@ -12403,6 +12467,10 @@ timers-browserify@^2.0.4:
 tiny-emitter@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/tiny-emitter/-/tiny-emitter-2.0.2.tgz#82d27468aca5ade8e5fd1e6d22b57dd43ebdfb7c"
+
+tinycolor2@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/tinycolor2/-/tinycolor2-1.4.1.tgz#f4fad333447bc0b07d4dc8e9209d8f39a8ac77e8"
 
 tinydate@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
- Update the default component prop to 'circular'.
- Add new prop `fullscreen` to allow a Loader on the entire screen.
- Add propTypes (this would be helpful if we start to use docz).
- Add addon-knobs to allow change some properties on the loader storybook.