### PR TITLE
DAG: no arrow heads for safari

### DIFF
--- a/packages/dag/src/dag.js
+++ b/packages/dag/src/dag.js
@@ -18,6 +18,7 @@ export const DEFAULTS = {
 
 const updateArrow = (arrow, line, nodeRadius) => {
   const triangleSize = 10;
+  if (typeof line.getPointAtLength !== 'function') return;
 
   const totalLength = line.getTotalLength() - (nodeRadius + 11.5); // yes, 11.5 is a magic number
   const startPoint = line.getPointAtLength(totalLength - triangleSize);


### PR DESCRIPTION
This PR closes #179. Its a temporal fix. 
Currently, there is no support on Safari for getPointAtLength and getTotalLength. This affects the arrowhead rendering on the graph. So the PR disables the arrow on Safari (& every other browser not implementing the previously mentioned functions)