### PR TITLE
Storybook: Fix bad webpack import

### DIFF
--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -1,0 +1,5 @@
+module.exports = (config) => {
+  config.module.rules[0].exclude = /node_modules/;
+
+  return config;
+}

--- a/packages/dag/src/index.js
+++ b/packages/dag/src/index.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import { createPortal } from 'react-dom';
 import classNames from 'classnames';
-import withStyles from '@material-ui/core/styles/withStyles';
+import { withStyles } from '@material-ui/core';
 import Input from '@material-ui/core/Input';
 import IconButton from '@material-ui/core/IconButton';
 import DeleteIcon from '@material-ui/icons/Delete';

--- a/packages/storybook-readme/package.json
+++ b/packages/storybook-readme/package.json
@@ -10,7 +10,8 @@
         "build": "rollup -c",
         "dev": "rollup -c -w",
         "test": "jest",
-        "pretest": "npm run build"
+        "pretest": "npm run build",
+        "prepublish": "npm run build"
     },
     "files": [
         "dist"


### PR DESCRIPTION
This PR:

- Adds `webpack.config.js` to handle `/node_modules/` exclusion (`packages` folder).
- Fixes `withStyles` from new **material-ui** lib.
- Adds `prepublish` npm script to **latticejs/storybook-readme**.