### PR TITLE
dag: add fallback for getting transform value from svg

### DIFF
--- a/packages/dag/src/index.js
+++ b/packages/dag/src/index.js
@@ -34,7 +34,8 @@ const styles = theme => ({
     color: theme.palette.text.secondary,
     fontFamily: theme.typography.fontFamily,
     fontSize: theme.typography.fontSize,
-    cursor: 'pointer'
+    cursor: 'pointer',
+    caretColor: 'transparent'
   },
   dagNode: {
     stroke: theme.palette.type === 'light' ? theme.palette.primary.light : theme.palette.secondary.dark,
@@ -113,7 +114,8 @@ class SvgTextInput extends Component {
           left: style.left(this.state.width),
           width: style.width(this.state.width),
           height: style.height,
-          transform: `scale(${style.z})`
+          transform: `scale(${style.z})`,
+          caretColor: 'initial'
         }}
       />,
       this.el
@@ -316,9 +318,9 @@ class Dag extends Component {
     if (!transform || transform === 'none') {
       // use another approach to get transform data
       const parseTransform = attr => {
-        var b = {};
-        for (var i in (attr = attr.match(/(\w+\((\-?\d+\.?\d*e?\-?\d*,?)+\))+/g))) {
-          var c = attr[i].match(/[\w\.\-]+/g);
+        const b = {};
+        for (let i in (attr = attr.match(/(\w+\((\-?\d+\.?\d*e?\-?\d*,?)+\))+/g))) {
+          const c = attr[i].match(/[\w\.\-]+/g);
           b[c.shift()] = c;
         }
         return b;
@@ -655,7 +657,7 @@ class Dag extends Component {
     return (
       <div
         ref={container => (this.graphContainer = container)}
-        style={{ position: 'relative', outline: 'none' }}
+        style={{ position: 'relative', outline: 'none', caretColor: 'transparent' }}
         contentEditable={true}
         suppressContentEditableWarning={true}
         onKeyUp={this.handleKeyUp}

--- a/packages/dag/test/__snapshots__/storyshot.test.js.snap
+++ b/packages/dag/test/__snapshots__/storyshot.test.js.snap
@@ -6,6 +6,7 @@ exports[`Storyshots dag/advanced editable mode 1`] = `
   onKeyUp={[Function]}
   style={
     Object {
+      "caretColor": "transparent",
       "outline": "none",
       "position": "relative",
     }
@@ -160,6 +161,7 @@ exports[`Storyshots dag/basic no wrapper 1`] = `
   onKeyUp={[Function]}
   style={
     Object {
+      "caretColor": "transparent",
       "outline": "none",
       "position": "relative",
     }
@@ -331,6 +333,7 @@ exports[`Storyshots dag/themed paper wrapper (dark) 1`] = `
       onKeyUp={[Function]}
       style={
         Object {
+          "caretColor": "transparent",
           "outline": "none",
           "position": "relative",
         }
@@ -504,6 +507,7 @@ exports[`Storyshots dag/themed paper wrapper (light) 1`] = `
       onKeyUp={[Function]}
       style={
         Object {
+          "caretColor": "transparent",
           "outline": "none",
           "position": "relative",
         }


### PR DESCRIPTION
This PR should close #234

The issue was related to [this FF issue](https://bugzilla.mozilla.org/show_bug.cgi?id=1435443). The fix involves getting the transform using a different method, in this case, I ended up parsing the element's attribute. It seems that FF and Safari do not fully implement the SVG2 spec.