### PR TITLE
example: dag-in-action height grows indefinitely on FF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 - [lattice-scripts] remove console.log call from lattice-script build step
+- [examples] dag-in-action height grows indefinitely on FF
 
 ## [1.0.1-beta.1] - 2018-11-13 [YANKED]
 

--- a/examples/dag-in-action/src/App.js
+++ b/examples/dag-in-action/src/App.js
@@ -96,7 +96,7 @@ const styles = theme => ({
   },
   dropzone: {
     width: '100%',
-    height: '100%'
+    height: '90vh'
   },
   instructions: {
     width: '500px',

--- a/examples/dag-in-action/src/App.js
+++ b/examples/dag-in-action/src/App.js
@@ -73,7 +73,11 @@ const styles = theme => ({
     flex: 1,
     overflow: 'scroll',
     '& > div': {
-      overflow: 'scroll'
+      overflow: 'scroll',
+      flexDirection: 'initial',
+      '& > div:first-child': {
+        width: '100%'
+      }
     }
   },
   columnItemTop: {


### PR DESCRIPTION
This PR closes #243 .

There was no issue with [react-container-dimensions](https://github.com/okonet/react-container-dimensions) package, even tried [react-resize-detector](https://github.com/maslianok/react-resize-detector), but same issue was faced on FF. But changing in CSS worked for both Chrome & FireFox.