### PR TITLE
Widget | New Release Beta-1.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Added Map Package.
 - Added ag-grid package.
 - Added Example of Mapbox, Sunburst && PieChart.
-- Readmes are updated.
+- Readmes are updated
 
 ## Update MUI version
 - Updated MUI version in dag package to 4.5.1.

--- a/packages/widgets/package.json
+++ b/packages/widgets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@latticejs/widgets",
-  "version": "1.0.1-beta.2",
+  "version": "1.0.1-beta.3",
   "license": "MIT",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",


### PR DESCRIPTION
In this PR, the version of the Widget is up to date to Beta-1.0.3. Used for release purpose only.

Self Reviewed
Rahul Garg