### PR TITLE
LJS-46 | Upgraded clap beta version upgraded from 1.0.1-beta.3 to 1.0.1-beta.4

### DIFF
--- a/packages/clap/package.json
+++ b/packages/clap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@latticejs/clap",
-  "version": "1.0.1-beta.3",
+  "version": "1.0.1-beta.4",
   "description": "Create Lattice App, the CLI for bootstraping your upcoming lattice app.",
   "main": "index.js",
   "preferGlobal": true,


### PR DESCRIPTION
In this PR, clap beta version has been upgraded to 1.0.1-beta.4