### PR TITLE
LJ-46 | Updated clap version from 1.0.1-beta.5 to 1.0.1-beta.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,8 +102,8 @@ Following examples are now upgraded to use Hooks.
 
   ## Update Phase - 2020-09-23
 - packages
-  - clap: fixed clap terminal warnings.
-  - clap: added shebang line in cli.js.
+  - clap: Fixed clap terminal warnings. Also Upgraded the version of clap package to 1.0.1-beta.6
+  - clap: Added shebang line in cli.js.
 
 [unreleased]: https://github.com/:latticejs/lattice/compare/v1.0.1-beta.1...HEAD
 [1.0.1-beta.1]: https://github.com/:latticejs/lattice/compare/v1.0.1-beta.0...v1.0.1-beta.1

--- a/packages/clap/package.json
+++ b/packages/clap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@latticejs/clap",
-  "version": "1.0.1-beta.5",
+  "version": "1.0.1-beta.6",
   "description": "Create Lattice App, the CLI for bootstraping your upcoming lattice app.",
   "main": "index.js",
   "preferGlobal": true,


### PR DESCRIPTION
In this PR, clap version has been upgraded from 1.0.1-beta.5 to 1.0.1-beta.6

Kindly Review,
Shivani Sharma